### PR TITLE
fix(ST-2707): trim text inputs value. use VcInput everywhere it posible

### DIFF
--- a/client-app/pages/account/orders.vue
+++ b/client-app/pages/account/orders.vue
@@ -79,7 +79,7 @@
           <VcInput
             v-model="localKeyword"
             class="w-full"
-            input-class="font-medium rounded-r-none !text-sm disabled:bg-gray-200 !pr-11"
+            input-class="font-medium rounded-r-none !text-sm disabled:bg-gray-200 !pl-4 !pr-11"
             :is-disabled="ordersLoading"
             @keypress.enter="applyKeyword"
             :placeholder="$t('pages.account.orders.search_placeholder')"

--- a/client-app/pages/account/orders.vue
+++ b/client-app/pages/account/orders.vue
@@ -76,10 +76,11 @@
 
       <div class="flex flex-grow mr-5 md:mx-0">
         <div class="relative grow">
-          <input
-            v-model.trim="localKeyword"
-            :disabled="ordersLoading"
-            class="w-full appearance-none bg-white rounded rounded-r-none h-11 pl-4 pr-11 font-medium outline-none text-sm border border-gray-300 focus:border-gray-400 disabled:bg-gray-200"
+          <VcInput
+            v-model="localKeyword"
+            class="w-full"
+            input-class="font-medium rounded-r-none !text-sm disabled:bg-gray-200 !pr-11"
+            :is-disabled="ordersLoading"
             @keypress.enter="applyKeyword"
             :placeholder="$t('pages.account.orders.search_placeholder')"
           />

--- a/client-app/pages/account/orders.vue
+++ b/client-app/pages/account/orders.vue
@@ -78,6 +78,7 @@
         <div class="relative grow">
           <VcInput
             v-model="localKeyword"
+            maxlength="64"
             class="w-full"
             input-class="font-medium rounded-r-none !text-sm disabled:bg-gray-200 !pl-4 !pr-11"
             :is-disabled="ordersLoading"

--- a/client-app/pages/company/members.vue
+++ b/client-app/pages/company/members.vue
@@ -34,6 +34,7 @@
         <div class="relative grow">
           <VcInput
             v-model="localKeyword"
+            maxlength="64"
             class="w-full"
             input-class="font-medium rounded-r-none !text-sm disabled:bg-gray-200 !pl-4 !pr-11"
             :is-disabled="loading"

--- a/client-app/pages/company/members.vue
+++ b/client-app/pages/company/members.vue
@@ -32,12 +32,13 @@
 
       <div class="flex flex-grow">
         <div class="relative grow">
-          <input
-            v-model.trim="localKeyword"
-            :disabled="loading"
-            :placeholder="$t('pages.company.members.search_placeholder')"
-            class="appearance-none bg-white rounded rounded-r-none h-11 pl-4 pr-11 font-medium outline-none text-sm border w-full border-gray-300 focus:border-gray-400 disabled:bg-gray-200"
+          <VcInput
+            v-model="localKeyword"
+            class="w-full"
+            input-class="font-medium rounded-r-none !text-sm disabled:bg-gray-200 !pl-4 !pr-11"
+            :is-disabled="loading"
             @keypress.enter="applyKeyword"
+            :placeholder="$t('pages.company.members.search_placeholder')"
           />
 
           <button v-if="localKeyword" class="absolute right-0 top-0 h-11 px-4" @click="resetKeyword">

--- a/client-app/pages/index.vue
+++ b/client-app/pages/index.vue
@@ -77,7 +77,7 @@
       <div class="flex flex-grow w-full space-x-6">
         <VcInput
           class="flex-grow"
-          :is-bordered="false"
+          :without-border="true"
           :placeholder="$t('pages.home.subscription_block.email_placeholder')"
         />
         <!-- todo: use VcButton -->

--- a/client-app/pages/index.vue
+++ b/client-app/pages/index.vue
@@ -75,8 +75,9 @@
         v-html="$t('pages.home.subscription_block.info_message')"
       ></div>
       <div class="flex flex-grow w-full space-x-6">
-        <input
-          class="bg-white rounded h-11 flex-grow shadow-inner px-4 min-w-0 outline-none"
+        <VcInput
+          class="flex-grow"
+          :is-bordered="false"
           :placeholder="$t('pages.home.subscription_block.email_placeholder')"
         />
         <!-- todo: use VcButton -->

--- a/client-app/shared/catalog/components/products-filters.vue
+++ b/client-app/shared/catalog/components/products-filters.vue
@@ -7,7 +7,7 @@
           <VcInput
             v-model="localKeyword"
             class="flex-1 w-full h-8"
-            inputClass="leading-8 !h-8 !pl-2 !pr-6"
+            input-class="leading-8 !h-8 !pl-2 !pr-6"
             maxlength="30"
             :is-disabled="loading"
             @keypress.enter="onSearchStart"

--- a/client-app/shared/catalog/components/products-filters.vue
+++ b/client-app/shared/catalog/components/products-filters.vue
@@ -4,12 +4,12 @@
     <VcFilterCard :title="$t('pages.catalog.search_card.title')" v-if="withLocalSearch">
       <div class="flex gap-2.5">
         <div class="relative">
-          <input
+          <VcInput
             v-model="localKeyword"
-            class="border rounded text-sm leading-8 flex-1 w-full border-gray-300 h-8 px-2 outline-none focus:border-gray-400"
-            type="text"
+            class="flex-1 w-full h-8"
+            inputClass="leading-8 !h-8 !pl-2 !pr-6"
             maxlength="30"
-            :disabled="loading"
+            :is-disabled="loading"
             @keypress.enter="onSearchStart"
           />
 

--- a/client-app/shared/layout/components/header/_internal/mobile-header.vue
+++ b/client-app/shared/layout/components/header/_internal/mobile-header.vue
@@ -49,7 +49,7 @@
         :placeholder="$t('shared.layout.header.mobile.search_bar.input_placeholder')"
         class="flex-grow mr-4 h-10"
         input-class="!h-10 !px-4 font-medium text-sm"
-        :is-bordered="false"
+        :without-border="true"
         @keyup.enter="$router.push(searchPageLink)"
       />
 

--- a/client-app/shared/layout/components/header/_internal/mobile-header.vue
+++ b/client-app/shared/layout/components/header/_internal/mobile-header.vue
@@ -43,11 +43,13 @@
 
     <!-- region Mobile Search Bar -->
     <div v-show="searchBarVisible" class="flex p-4 bg-[color:var(--color-search-bar-bg)] select-none">
-      <input
-        v-model.trim="searchPhrase"
-        maxlength="30"
+      <VcInput
+        v-model="searchPhrase"
+        maxlength="64"
         :placeholder="$t('shared.layout.header.mobile.search_bar.input_placeholder')"
-        class="flex-grow mr-4 rounded h-10 px-4 font-medium text-sm outline-none disabled:bg-gray-200"
+        class="flex-grow mr-4 h-10"
+        input-class="!h-10 !px-4 font-medium text-sm"
+        :is-bordered="false"
         @keyup.enter="$router.push(searchPageLink)"
       />
 

--- a/client-app/ui-kit/components/atoms/action-input/vc-action-input.vue
+++ b/client-app/ui-kit/components/atoms/action-input/vc-action-input.vue
@@ -3,7 +3,7 @@
     <p v-if="label" class="text-base pb-2 font-extrabold">{{ label }}</p>
     <div class="flex space-x-3">
       <input
-        v-model="value"
+        v-model.trim="value"
         class="border rounded text-base leading-8 flex-1 border-gray-300 h-8 px-2 outline-none focus:border-gray-400 min-w-0"
         type="text"
         :placeholder="placeholder"

--- a/client-app/ui-kit/components/atoms/input/vc-input.vue
+++ b/client-app/ui-kit/components/atoms/input/vc-input.vue
@@ -7,8 +7,8 @@
 
     <div class="relative h-11">
       <input
-        class="appearance-none rounded h-full px-3 text-base leading-none box-border border border-gray-300 w-full outline-none focus:border-gray-400 min-w-0"
-        :class="{ 'pr-12': isPasswordIconVisible }"
+        class="appearance-none rounded h-full px-3 text-base leading-none box-border w-full outline-none min-w-0"
+        :class="{ 'pr-12': isPasswordIconVisible, 'border border-gray-300 focus:border-gray-400': isBordered }"
         :value="modelValue"
         :type="inputType"
         :name="name"
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watchEffect } from "vue";
+import { computed, PropType, ref, watchEffect } from "vue";
 
 const emit = defineEmits(["update:modelValue"]);
 
@@ -50,6 +50,7 @@ const props = defineProps({
   isReadonly: Boolean,
   isDisabled: Boolean,
   isRequired: Boolean,
+  isBordered: { type: Boolean, default: true },
   hidePasswordSwitcher: Boolean,
   label: String,
   name: String,
@@ -67,7 +68,7 @@ const props = defineProps({
   },
 
   type: {
-    type: String,
+    type: String as PropType<"text" | "password" | "number">,
     default: "text",
   },
 });

--- a/client-app/ui-kit/components/atoms/input/vc-input.vue
+++ b/client-app/ui-kit/components/atoms/input/vc-input.vue
@@ -10,7 +10,7 @@
         class="appearance-none rounded h-full px-3 text-base leading-none box-border w-full outline-none min-w-0"
         :class="[
           inputClass,
-          { 'pr-12': isPasswordIconVisible, 'border border-gray-300 focus:border-gray-400': isBordered },
+          { 'pr-12': isPasswordIconVisible, 'border border-gray-300 focus:border-gray-400': !withoutBorder },
         ]"
         :value="modelValue"
         :type="inputType"
@@ -53,7 +53,7 @@ const props = defineProps({
   isReadonly: Boolean,
   isDisabled: Boolean,
   isRequired: Boolean,
-  isBordered: { type: Boolean, default: true },
+  withoutBorder: { type: Boolean, default: false },
   hidePasswordSwitcher: Boolean,
   label: String,
   name: String,

--- a/client-app/ui-kit/components/atoms/input/vc-input.vue
+++ b/client-app/ui-kit/components/atoms/input/vc-input.vue
@@ -92,8 +92,13 @@ function change(event: Event) {
   if (props.isDisabled) {
     return;
   }
-  const newValue: string = (event.target as HTMLInputElement).value.trim();
-  emit("update:modelValue", props.type === "number" ? Number(newValue) : newValue);
+  let value: string = (event.target as HTMLInputElement).value;
+
+  if (props.type !== "password") {
+    value = value.trim();
+  }
+
+  emit("update:modelValue", props.type === "number" ? Number(value) : value);
 }
 
 watchEffect(() => {

--- a/client-app/ui-kit/components/atoms/input/vc-input.vue
+++ b/client-app/ui-kit/components/atoms/input/vc-input.vue
@@ -8,7 +8,10 @@
     <div class="relative h-11">
       <input
         class="appearance-none rounded h-full px-3 text-base leading-none box-border w-full outline-none min-w-0"
-        :class="{ 'pr-12': isPasswordIconVisible, 'border border-gray-300 focus:border-gray-400': isBordered }"
+        :class="[
+          inputClass,
+          { 'pr-12': isPasswordIconVisible, 'border border-gray-300 focus:border-gray-400': isBordered },
+        ]"
         :value="modelValue"
         :type="inputType"
         :name="name"
@@ -61,6 +64,7 @@ const props = defineProps({
   minlength: [String, Number],
   maxlength: [String, Number],
   errorMessage: String,
+  inputClass: String,
 
   modelValue: {
     type: [String, Number],


### PR DESCRIPTION
Description:

Find all input elements without VcInput component usage. 

use VcInput if it is possible.

use the ‘trim’ modifier in other cases. 

Fix VcInput. Don’t use trimming to type 'password'

check the trimming algoritm on possible improvements 

--

QA-test:  ST-2709

Demo-test:

Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.8.0-pr-285-6ac1dc97.zip
