### PR TITLE
remove address name from popup

### DIFF
--- a/client-app/pages/company/info.vue
+++ b/client-app/pages/company/info.vue
@@ -239,7 +239,7 @@ import { computedEager } from "@vueuse/core";
 import { useField } from "vee-validate";
 import * as yup from "yup";
 import { MemberAddressType } from "@/xapi";
-import { AddressType, getAddressName, ISortInfo, usePageHead, XApiPermissions } from "@/core";
+import { AddressType, ISortInfo, usePageHead, XApiPermissions } from "@/core";
 import { useUser } from "@/shared/account";
 import { usePopup } from "@/shared/popup";
 import { AddOrUpdateCompanyAddressDialog, useOrganization, useOrganizationAddresses } from "@/shared/company";
@@ -360,7 +360,7 @@ async function openDeleteAddressDialog(address: MemberAddressType) {
         await removeAddresses([address]);
 
         notifications.success({
-          text: t("pages.company.info.address_deletion_successful_message", { addressName: getAddressName(address) }),
+          text: t("pages.company.info.address_deletion_successful_message"),
           duration: 10000,
           single: true,
         });
@@ -391,9 +391,7 @@ async function openAddOrUpdateCompanyAddressDialog(address?: MemberAddressType):
         await addOrUpdateAddresses([updatedAddress]);
 
         notifications.success({
-          text: t("pages.company.info.address_saved_successful_message", {
-            addressName: getAddressName(updatedAddress),
-          }),
+          text: t("pages.company.info.address_saved_successful_message"),
           duration: 10000,
           single: true,
         });

--- a/locales/de.json
+++ b/locales/de.json
@@ -1010,8 +1010,8 @@
         "content_header": "Addresses",
         "no_addresses_message": "There are no addresses yet",
         "address_not_delete_message": "The default address cannot be deleted",
-        "address_deletion_successful_message": "Address ”{addressName}” has been successfully deleted",
-        "address_saved_successful_message": "Address ”{addressName}” has been successfully saved",
+        "address_deletion_successful_message": "Address has been successfully deleted",
+        "address_saved_successful_message": "Address has been successfully saved",
         "labels": {
           "company_name": "Company Name",
           "address": "Address",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1008,8 +1008,8 @@
         "content_header": "Addresses",
         "no_addresses_message": "There are no addresses yet",
         "address_not_delete_message": "The default address cannot be deleted",
-        "address_deletion_successful_message": "Address ”{addressName}” has been successfully deleted",
-        "address_saved_successful_message": "Address ”{addressName}” has been successfully saved",
+        "address_deletion_successful_message": "Address has been successfully deleted",
+        "address_saved_successful_message": "Address has been successfully saved",
         "labels": {
           "company_name": "Company Name",
           "address": "Address",


### PR DESCRIPTION
Description:
https://virtocommerce.atlassian.net/browse/ST-3189

Exclude address info from the popup.
the txt shall be “Address has been successfully saved.“
--

QA-test:

Demo-test:

Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.17.0-pr-391-7b34-7b3438ad.zip
