### PR TITLE
fix: url without initial slash in breadcrumbs

### DIFF
--- a/client-app/shared/catalog/composables/useBreadcrumbs.ts
+++ b/client-app/shared/catalog/composables/useBreadcrumbs.ts
@@ -1,22 +1,22 @@
 import { useI18n } from "vue-i18n";
-import { IBreadcrumbsItem } from "./../types/index";
-import { Breadcrumb } from "@/xapi/types";
+import { Breadcrumb } from "@/xapi";
+import { IBreadcrumbsItem } from "@/shared/catalog";
 
 // TODO: move this logic to core level into the separated helper. Use it everywhere can be needful
 export default () => {
   const { t } = useI18n();
 
-  function buildBreadcrumbs(breadcrumbs: Breadcrumb[]) {
-    const result: IBreadcrumbsItem[] = [{ url: "/", title: t("common.links.home") }];
+  function buildBreadcrumbs(items: Breadcrumb[]): IBreadcrumbsItem[] {
+    const homepage: IBreadcrumbsItem = {
+      title: t("common.links.home"),
+      url: "/",
+    };
+    const breadcrumbs = items.map(({ title, seoPath }) => ({
+      title,
+      url: seoPath?.startsWith("/") ? seoPath : "/" + seoPath,
+    }));
 
-    breadcrumbs.forEach((breadcrumb) =>
-      result.push({
-        title: breadcrumb.title,
-        url: breadcrumb.seoPath,
-      })
-    );
-
-    return result;
+    return [homepage].concat(breadcrumbs);
   }
 
   return {


### PR DESCRIPTION
Description:


--

QA-test:

Demo-test:

Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.19.0-pr-422-7885-7885f4b5.zip
