### PR TITLE
fix: mobile-menu-link break-words

### DIFF
--- a/client-app/shared/layout/components/header/_internal/mobile-menu-link.vue
+++ b/client-app/shared/layout/components/header/_internal/mobile-menu-link.vue
@@ -26,7 +26,7 @@
         </svg>
       </slot>
 
-      <span class="line-clamp-3">
+      <span class="break-words line-clamp-3">
         <slot v-bind="{ isActive, isExactActive }" />
       </span>
 


### PR DESCRIPTION
Description:
https://virtocommerce.atlassian.net/browse/ST-2901

--

QA-test:

Demo-test:

Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.24.0-pr-492-1623-1623c384.zip
