### PR TITLE
fix: fixate yarn 1.x and node.js 16 versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 package-lock=false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "vue-eslint-parser": "^9.3.0",
     "vue-loader": "^17.1.2",
     "vue-tsc": "1.6.5",
-    "yarn": "^1.22.19"
+    "yarn": "1.22.19"
   },
   "lint-staged": {
     "*.{js,ts,vue}": [
@@ -131,5 +131,6 @@
   },
   "resolutions": {
     "@types/react": "file:stub/@types/react"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     ]
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.0.0 <17.0.0"
   },
   "resolutions": {
     "@types/react": "file:stub/@types/react"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16497,7 +16497,7 @@ yargs@^7.1.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.1"
 
-yarn@^1.22.19:
+yarn@1.22.19:
   version "1.22.19"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
   integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==


### PR DESCRIPTION
Description:


--

QA-test:

Demo-test:

Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.35.0-pr-645-d71d-d71dea0f.zip
