### PR TITLE
fix: remove lazy for large content paint images

### DIFF
--- a/client-app/core/constants/images.ts
+++ b/client-app/core/constants/images.ts
@@ -1,0 +1,1 @@
+export const NO_IMAGE_URL = "/static/images/common/no-image.svg";

--- a/client-app/core/constants/index.ts
+++ b/client-app/core/constants/index.ts
@@ -1,4 +1,5 @@
 export * from "./environment";
+export * from "./images";
 export * from "./notifications";
 export * from "./products";
 export * from "./search";

--- a/client-app/core/constants/index.ts
+++ b/client-app/core/constants/index.ts
@@ -3,4 +3,5 @@ export * from "./notifications";
 export * from "./products";
 export * from "./search";
 export * from "./security";
+export * from "./tailwind";
 export * from "./wishlists";

--- a/client-app/core/constants/tailwind.ts
+++ b/client-app/core/constants/tailwind.ts
@@ -1,0 +1,10 @@
+import type { Config } from "tailwindcss";
+
+export const BREAKPOINTS: Config["screens"] = {
+  xs: "480px",
+  sm: "640px",
+  md: "768px",
+  lg: "1024px",
+  xl: "1280px",
+  "2xl": "1500px",
+};

--- a/client-app/shared/catalog/components/category.vue
+++ b/client-app/shared/catalog/components/category.vue
@@ -295,7 +295,6 @@
 
 <script setup lang="ts">
 import {
-  breakpointsTailwind,
   computedEager,
   useBreakpoints,
   useElementBounding,
@@ -345,8 +344,6 @@ interface IProps {
 const props = defineProps<IProps>();
 
 const { catalogId, currencyCode } = globals;
-
-const t = breakpointsTailwind;
 
 const { themeContext } = useThemeContext();
 const { openPopup } = usePopup();

--- a/client-app/shared/catalog/components/category.vue
+++ b/client-app/shared/catalog/components/category.vue
@@ -244,11 +244,6 @@
               :view-mode="savedViewMode"
               :items-per-page="itemsPerPage"
               :products="products"
-              :class="
-                savedViewMode === 'list'
-                  ? '-mx-5 divide-y lg:divide-y-0 lg:mx-0 lg:space-y-3.5'
-                  : 'grid gap-6 xs:grid-cols-2 md:grid-cols-3 lg:gap-5 xl:grid-cols-4'
-              "
               open-product-in-new-tab
               @item-link-click="sendGASelectItemEvent"
             >
@@ -318,7 +313,7 @@ import {
   useRouteQueryParam,
   useThemeContext,
 } from "@/core/composables";
-import { DEFAULT_PAGE_SIZE, PRODUCT_SORTING_LIST } from "@/core/constants";
+import { BREAKPOINTS, DEFAULT_PAGE_SIZE, PRODUCT_SORTING_LIST } from "@/core/constants";
 import { QueryParamName } from "@/core/enums";
 import { globals } from "@/core/globals";
 import {
@@ -351,9 +346,11 @@ const props = defineProps<IProps>();
 
 const { catalogId, currencyCode } = globals;
 
+const t = breakpointsTailwind;
+
 const { themeContext } = useThemeContext();
 const { openPopup } = usePopup();
-const breakpoints = useBreakpoints(breakpointsTailwind);
+const breakpoints = useBreakpoints(BREAKPOINTS);
 const ga = useGoogleAnalytics();
 const {
   fetchProducts,
@@ -451,11 +448,11 @@ const searchParams = computedEager<ProductsSearchParams>(() => ({
 }));
 
 const isExistSelectedFacets = computedEager<boolean>(() =>
-  facets.value.some((facet) => facet.values.some((value) => value.selected))
+  facets.value.some((facet) => facet.values.some((value) => value.selected)),
 );
 
 const isExistSelectedMobileFacets = computedEager<boolean>(() =>
-  mobileFilters.facets.some((facet) => facet.values.some((value) => value.selected))
+  mobileFilters.facets.some((facet) => facet.values.some((value) => value.selected)),
 );
 
 const isMobileFilterDirty = computedEager<boolean>(
@@ -465,7 +462,7 @@ const isMobileFilterDirty = computedEager<boolean>(
       facets: facets.value,
       inStock: savedInStock.value,
       branches: savedBranches.value,
-    } as ProductsFilters)
+    } as ProductsFilters),
 );
 
 function sendGASelectItemEvent(product: Product) {
@@ -708,7 +705,7 @@ watch(
       });
     }
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 watch(
@@ -717,14 +714,14 @@ watch(
     if (value !== oldValue) {
       setFiltersPosition();
     }
-  }
+  },
 );
 
 watch(
   () => cHeight.value,
   () => {
     setFiltersPosition();
-  }
+  },
 );
 
 watchDebounced(
@@ -734,6 +731,6 @@ watchDebounced(
     immediate: true,
     flush: "post",
     debounce: 20,
-  }
+  },
 );
 </script>

--- a/client-app/shared/catalog/components/display-products.vue
+++ b/client-app/shared/catalog/components/display-products.vue
@@ -70,6 +70,7 @@ const columns = {
   md: 3,
   xl: 4,
 };
+
 const cssColumns = computed(() =>
   Object.entries(columns)
     .map(([key, value]) => {
@@ -78,31 +79,50 @@ const cssColumns = computed(() =>
     })
     .join(" "),
 );
+
 const lazyCardsCount = computed(() => {
   if (props.viewMode === "grid") {
-    const rowCount = 2;
-    if (breakpoints.isSmaller("xs")) {
-      return columns.null;
-    } else if (breakpoints.isInBetween("xs", "md")) {
-      return columns.xs * rowCount;
-    } else if (breakpoints.isInBetween("md", "xl")) {
-      return columns.md * rowCount;
-    } else if (breakpoints.isGreaterOrEqual("xl")) {
-      return columns.xl * rowCount;
-    }
-  } else if (props.viewMode == "list") {
-    if (breakpoints.isSmaller("xs")) {
-      return 2;
-    } else if (breakpoints.isInBetween("xs", "sm")) {
-      return 4;
-    } else if (breakpoints.isInBetween("sm", "lg")) {
-      return 6;
-    } else if (breakpoints.isInBetween("lg", "2xl")) {
-      return 4;
-    } else if (breakpoints.isGreaterOrEqual("2xl")) {
-      return 5;
-    }
+    return getGridLazyCardsCount();
+  }
+  if (props.viewMode == "list") {
+    return getListLazyCardsCount();
   }
   return 0;
 });
+
+function getGridLazyCardsCount() {
+  const rowCount = 2;
+  if (breakpoints.isSmaller("xs")) {
+    return columns.null;
+  }
+  if (breakpoints.isInBetween("xs", "md")) {
+    return columns.xs * rowCount;
+  }
+  if (breakpoints.isInBetween("md", "xl")) {
+    return columns.md * rowCount;
+  }
+  if (breakpoints.isGreaterOrEqual("xl")) {
+    return columns.xl * rowCount;
+  }
+  return 0;
+}
+
+function getListLazyCardsCount() {
+  if (breakpoints.isSmaller("xs")) {
+    return 2;
+  }
+  if (breakpoints.isInBetween("xs", "sm")) {
+    return 4;
+  }
+  if (breakpoints.isInBetween("sm", "lg")) {
+    return 6;
+  }
+  if (breakpoints.isInBetween("lg", "2xl")) {
+    return 4;
+  }
+  if (breakpoints.isGreaterOrEqual("2xl")) {
+    return 5;
+  }
+  return 0;
+}
 </script>

--- a/client-app/shared/catalog/components/display-products.vue
+++ b/client-app/shared/catalog/components/display-products.vue
@@ -1,5 +1,9 @@
 <template>
-  <div>
+  <div
+    :class="
+      viewMode === 'list' ? '-mx-5 divide-y lg:divide-y-0 lg:mx-0 lg:space-y-3.5' : 'grid gap-6 lg:gap-5 ' + cssColumns
+    "
+  >
     <template v-if="loading">
       <component :is="skeletonComponent" v-for="i in itemsPerPage" :key="i" />
     </template>
@@ -10,6 +14,7 @@
         v-for="(item, index) in products"
         :key="item.id + index"
         :product="item"
+        :lazy="index >= lazyCardsCount"
         :open-in-new-tab="openProductInNewTab"
         @link-click="$emit('itemLinkClick', item, $event)"
       >
@@ -25,21 +30,18 @@
 </template>
 
 <script setup lang="ts">
+import { useBreakpoints } from "@vueuse/core";
 import { computed } from "vue";
-import { DEFAULT_PAGE_SIZE } from "@/core/constants";
+import { BREAKPOINTS, DEFAULT_PAGE_SIZE } from "@/core/constants";
 import ProductCardGrid from "./product-card-grid.vue";
 import ProductCardList from "./product-card-list.vue";
 import ProductSkeletonGrid from "./product-skeleton-grid.vue";
 import ProductSkeletonList from "./product-skeleton-list.vue";
 import type { Product } from "@/core/api/graphql/types";
 
-defineEmits<{ (eventName: "itemLinkClick", product: Product, globalEvent: PointerEvent): void }>();
-
-const props = withDefaults(defineProps<IProps>(), {
-  itemsPerPage: DEFAULT_PAGE_SIZE,
-  products: () => [],
-  viewMode: "grid",
-});
+interface IEmits {
+  (eventName: "itemLinkClick", product: Product, globalEvent: PointerEvent): void;
+}
 
 interface IProps {
   loading: boolean;
@@ -49,6 +51,58 @@ interface IProps {
   openProductInNewTab?: boolean;
 }
 
-const cardComponent = computed(() => (props.viewMode === "list" ? ProductCardList : ProductCardGrid));
+defineEmits<IEmits>();
+
+const props = withDefaults(defineProps<IProps>(), {
+  itemsPerPage: DEFAULT_PAGE_SIZE,
+  products: () => [],
+  viewMode: "grid",
+});
+
+const breakpoints = useBreakpoints(BREAKPOINTS);
+
 const skeletonComponent = computed(() => (props.viewMode === "list" ? ProductSkeletonList : ProductSkeletonGrid));
+const cardComponent = computed(() => (props.viewMode === "list" ? ProductCardList : ProductCardGrid));
+
+const columns = {
+  null: 1,
+  xs: 2,
+  md: 3,
+  xl: 4,
+};
+const cssColumns = computed(() =>
+  Object.entries(columns)
+    .map(([key, value]) => {
+      const delimiter = key ? ":" : "";
+      return `${key}${delimiter}grid-cols-${value}`;
+    })
+    .join(" "),
+);
+const lazyCardsCount = computed(() => {
+  if (props.viewMode === "grid") {
+    const rowCount = 2;
+    if (breakpoints.isSmaller("xs")) {
+      return columns.null;
+    } else if (breakpoints.isInBetween("xs", "md")) {
+      return columns.xs * rowCount;
+    } else if (breakpoints.isInBetween("md", "xl")) {
+      return columns.md * rowCount;
+    } else if (breakpoints.isGreaterOrEqual("xl")) {
+      return columns.xl * rowCount;
+    }
+  } else if (props.viewMode == "list") {
+    if (breakpoints.isSmaller("xs")) {
+      return 2;
+    } else if (breakpoints.isInBetween("xs", "sm")) {
+      return 4;
+    } else if (breakpoints.isInBetween("sm", "lg")) {
+      return 6;
+    } else if (breakpoints.isInBetween("lg", "2xl")) {
+      return 4;
+    } else if (breakpoints.isGreaterOrEqual("2xl")) {
+      return 5;
+    }
+  }
+  return 0;
+});
 </script>

--- a/client-app/shared/catalog/components/product-card-grid.vue
+++ b/client-app/shared/catalog/components/product-card-grid.vue
@@ -7,7 +7,7 @@
       <div class="absolute top-0 h-full w-full rounded">
         <template v-if="$cfg.image_carousel_in_product_card_enabled && product.images?.length">
           <Swiper
-            :modules="[Pagination, Navigation, Lazy]"
+            :modules="[Pagination, Navigation]"
             :navigation="{
               nextEl: '.carousel-button-next',
               prevEl: '.carousel-button-prev',
@@ -15,7 +15,6 @@
             }"
             class="h-full w-full"
             rewind
-            lazy
             @swiper="swiperInstance = $event"
             @slide-change="slideChanged"
           >
@@ -26,7 +25,7 @@
                 size-suffix="md"
                 :class="{ 'cursor-pointer': swiperInstance?.allowSlideNext }"
                 class="h-full w-full select-none rounded object-cover object-center"
-                lazy
+                :lazy="lazy || index > 0"
                 @click="swiperInstance?.slideNext()"
               />
             </SwiperSlide>
@@ -81,7 +80,7 @@
           :alt="product.name"
           size-suffix="md"
           class="h-full w-full rounded object-cover object-center"
-          lazy
+          :lazy="lazy"
         />
       </div>
 
@@ -210,7 +209,7 @@
 </template>
 
 <script setup lang="ts">
-import { Pagination, Navigation, Lazy } from "swiper";
+import { Pagination, Navigation } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/vue";
 import { computed, ref } from "vue";
 import { ProductType, PropertyType } from "@/core/enums";
@@ -229,6 +228,7 @@ const props = defineProps<IProps>();
 
 interface IProps {
   product: Product;
+  lazy: boolean;
   openInNewTab?: boolean;
 }
 
@@ -239,7 +239,7 @@ const link = computed<RouteLocationRaw>(() => getProductRoute(props.product.id, 
 const target = computed<string>(() => getLinkTarget(props.openInNewTab));
 const isDigital = computed<boolean>(() => props.product.productType === ProductType.Digital);
 const properties = computed(() =>
-  Object.values(getPropertiesGroupedByName(props.product.properties ?? [], PropertyType.Product)).slice(0, 3)
+  Object.values(getPropertiesGroupedByName(props.product.properties ?? [], PropertyType.Product)).slice(0, 3),
 );
 
 function slideChanged(swiper: SwiperInstance) {

--- a/client-app/shared/catalog/components/product-card-list.vue
+++ b/client-app/shared/catalog/components/product-card-list.vue
@@ -14,7 +14,7 @@
           :alt="product.name"
           size-suffix="md"
           class="h-full w-full rounded object-cover object-center"
-          lazy
+          :lazy="lazy"
         />
         <DiscountBadge :price="product.price!" size="sm" />
       </router-link>
@@ -167,6 +167,7 @@ const props = defineProps<IProps>();
 
 interface IProps {
   product: Product;
+  lazy: boolean;
   openInNewTab?: boolean;
 }
 
@@ -174,7 +175,7 @@ const link = computed<RouteLocationRaw>(() => getProductRoute(props.product.id, 
 const target = computed<string>(() => getLinkTarget(props.openInNewTab));
 const isDigital = computed<boolean>(() => props.product.productType === ProductType.Digital);
 const properties = computed(() =>
-  Object.values(getPropertiesGroupedByName(props.product.properties ?? [], PropertyType.Product)).slice(0, 3)
+  Object.values(getPropertiesGroupedByName(props.product.properties ?? [], PropertyType.Product)).slice(0, 3),
 );
 </script>
 

--- a/client-app/shared/static-content/components/slider.vue
+++ b/client-app/shared/static-content/components/slider.vue
@@ -6,7 +6,7 @@
       <Swiper :slides-per-view="1" class="w-full" :modules="modules" :navigation="navigationOptions">
         <SwiperSlide v-for="(item, index) in model.slides" :key="index" class="text-center">
           <div>
-            <VcImage :src="item.image" class="place-items-center" lazy />
+            <VcImage :src="item.image" class="place-items-center" :lazy="index > 0" />
             <div v-if="item.title" class="mb-3 font-roboto-condensed text-2xl font-bold uppercase">
               {{ item.title }}
             </div>

--- a/client-app/shims-vueuse.d.ts
+++ b/client-app/shims-vueuse.d.ts
@@ -1,0 +1,8 @@
+import "@vueuse/core";
+
+export {};
+
+declare module "@vueuse/core" {
+  /** @deprecated Use `BREAKPOINTS` from `import { BREAKPOINTS } from @/core/constants` instead */
+  declare const breakpointsTailwind;
+}

--- a/client-app/shims-vueuse.d.ts
+++ b/client-app/shims-vueuse.d.ts
@@ -1,8 +1,0 @@
-import "@vueuse/core";
-
-export {};
-
-declare module "@vueuse/core" {
-  /** @deprecated Use `BREAKPOINTS` from `import { BREAKPOINTS } from "@/core/constants"` instead */
-  declare const breakpointsTailwind;
-}

--- a/client-app/shims-vueuse.d.ts
+++ b/client-app/shims-vueuse.d.ts
@@ -3,6 +3,6 @@ import "@vueuse/core";
 export {};
 
 declare module "@vueuse/core" {
-  /** @deprecated Use `BREAKPOINTS` from `import { BREAKPOINTS } from @/core/constants` instead */
+  /** @deprecated Use `BREAKPOINTS` from `import { BREAKPOINTS } from "@/core/constants"` instead */
   declare const breakpointsTailwind;
 }

--- a/client-app/ui-kit/components/atoms/image/vc-image.vue
+++ b/client-app/ui-kit/components/atoms/image/vc-image.vue
@@ -2,7 +2,7 @@
   <img
     :src="preparedSrc"
     :alt="alt"
-    :loading="lazy ? 'lazy' : null"
+    :loading="lazy ? 'lazy' : 'eager'"
     :data-src="fallbackEnabled ? src : null"
     :data-size-suffix="fallbackEnabled || originalEnabled ? sizeSuffix : null"
     :class="{ 'object-scale-down object-center': preparedSrc === fallbackSrc }"
@@ -14,35 +14,23 @@
 import { computed, inject, ref, watch } from "vue";
 import { configInjectionKey } from "@/core/injection-keys";
 import { appendSuffixToFilename } from "@/core/utilities";
-import type { PropType } from "vue";
 
-const props = defineProps({
-  lazy: Boolean,
-
-  src: {
-    type: String,
-    default: "",
-  },
-
-  alt: {
-    type: String,
-    default: null,
-  },
-
-  fallbackSrc: {
-    type: String,
-    default: "/static/images/common/no-image.svg",
-  },
-
+export interface IProps {
+  lazy?: boolean;
+  src?: string;
+  alt?: string;
+  fallbackSrc?: string;
   /**
    * First you need to generate thumbnails in admin panel, section "Thumbnails" (vc-module-image-tools).
    * You can also set suffixes there.
    * @see https://github.com/VirtoCommerce/vc-module-image-tools
    */
-  sizeSuffix: {
-    type: String as PropType<"sm" | "md" | "lg">,
-    validator: (value: string) => ["sm", "md", "lg"].includes(value),
-  },
+  sizeSuffix?: "sm" | "md" | "lg";
+}
+
+const props = withDefaults(defineProps<IProps>(), {
+  src: "",
+  fallbackSrc: "/static/images/common/no-image.svg",
 });
 
 const cfg = inject(configInjectionKey);
@@ -86,6 +74,6 @@ watch(
   () => {
     fallbackEnabled.value = false;
     originalEnabled.value = false;
-  }
+  },
 );
 </script>

--- a/client-app/ui-kit/components/atoms/image/vc-image.vue
+++ b/client-app/ui-kit/components/atoms/image/vc-image.vue
@@ -12,6 +12,7 @@
 
 <script setup lang="ts">
 import { computed, inject, ref, watch } from "vue";
+import { NO_IMAGE_URL } from "@/core/constants";
 import { configInjectionKey } from "@/core/injection-keys";
 import { appendSuffixToFilename } from "@/core/utilities";
 
@@ -30,7 +31,7 @@ export interface IProps {
 
 const props = withDefaults(defineProps<IProps>(), {
   src: "",
-  fallbackSrc: "/static/images/common/no-image.svg",
+  fallbackSrc: NO_IMAGE_URL,
 });
 
 const cfg = inject(configInjectionKey);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,18 +1,11 @@
-const colors = require("tailwindcss/colors");
+import { BREAKPOINTS } from "./client-app/core/constants/tailwind";
+import type { Config } from "tailwindcss";
 
-/** @type {import("tailwindcss").Config} */
 module.exports = {
   content: ["./index.html", "./client-app/**/*.{vue,js,ts,jsx,tsx}"],
 
   theme: {
-    screens: {
-      xs: "480px",
-      sm: "640px",
-      md: "768px",
-      lg: "1024px",
-      xl: "1280px",
-      "2xl": "1500px",
-    },
+    screens: BREAKPOINTS,
     fontFamily: {
       lato: ["Lato", "sans-serif"],
       roboto: ["Roboto", "sans-serif"],
@@ -164,9 +157,7 @@ module.exports = {
             lineHeight: "0.875rem", //14px
           },
         ],
-        10: [
-          "0.625rem", //10px
-        ],
+        10: "0.625rem", //10px
         11: [
           "0.6875rem", //11px
           {
@@ -230,9 +221,7 @@ module.exports = {
             lineHeight: "1.563rem", //25px
           },
         ],
-        24: [
-          "1.5rem", //24px
-        ],
+        24: "1.5rem", //24px
         25: [
           "1.5625rem", //25px
           {
@@ -283,4 +272,4 @@ module.exports = {
       },
     },
   },
-};
+} satisfies Config;


### PR DESCRIPTION
Description:
https://virtocommerce.atlassian.net/browse/ST-4743

After this PR will be merged, use `BREAKPOINTS` from `import { BREAKPOINTS } from "@/core/constants"` instead of `breakpointsTailwind` from `import { breakpointsTailwind } from "@vueuse/core"`.

--

QA-test:

Demo-test:

Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.37.0-pr-677-ac8c-ac8ce4b7.zip
