### PR TITLE
fix: bank card expiration year validation

### DIFF
--- a/client-app/shared/payment/components/bank-card-form.vue
+++ b/client-app/shared/payment/components/bank-card-form.vue
@@ -113,21 +113,20 @@ const labels = computed(() => {
   };
 });
 
+const yupMonthFieldSchema = string()
+  .required()
+  .length(2)
+  .matches(/^(0?[1-9]|1[0-2])$/, t("shared.payment.authorize_net.errors.month"))
+  .label(labels.value.monthLabel);
+
 const validationSchema = toTypedSchema(
   object({
     number: string().required().min(12).max(19).label(labels.value.number),
     cardholderName: string().required().max(64).label(labels.value.cardholderName),
-    month: string()
-      .required()
-      .length(2)
-      .matches(/^(0?[1-9]|1[012])$/, t("shared.payment.authorize_net.errors.month"))
-      .label(labels.value.monthLabel),
-    year: string()
-      .when("month", {
-        is: (monthValue?: string) => monthValue?.length === 2,
-        then: (stringSchema) => stringSchema.length(2),
-      })
-      .label(labels.value.yearLabel),
+    month: yupMonthFieldSchema,
+    year: string().when("month", ([month], schema) => {
+      return yupMonthFieldSchema.isValidSync(month) ? schema.length(2).label(labels.value.yearLabel) : schema;
+    }),
     securityCode: string().required().min(3).max(4).label(labels.value.securityCode),
   }),
 );

--- a/client-app/shared/payment/components/bank-card-form.vue
+++ b/client-app/shared/payment/components/bank-card-form.vue
@@ -113,7 +113,7 @@ const labels = computed(() => {
   };
 });
 
-const yupMonthFieldSchema = string()
+const monthYupSchema = string()
   .required()
   .length(2)
   .matches(/^(0?[1-9]|1[0-2])$/, t("shared.payment.authorize_net.errors.month"))
@@ -123,9 +123,9 @@ const validationSchema = toTypedSchema(
   object({
     number: string().required().min(12).max(19).label(labels.value.number),
     cardholderName: string().required().max(64).label(labels.value.cardholderName),
-    month: yupMonthFieldSchema,
+    month: monthYupSchema,
     year: string().when("month", ([month], schema) => {
-      return yupMonthFieldSchema.isValidSync(month) ? schema.length(2).label(labels.value.yearLabel) : schema;
+      return monthYupSchema.isValidSync(month) ? schema.length(2).label(labels.value.yearLabel) : schema;
     }),
     securityCode: string().required().min(3).max(4).label(labels.value.securityCode),
   }),


### PR DESCRIPTION
Description:
https://virtocommerce.atlassian.net/browse/ST-4980
Now:
* Validates only after month
* Label is correctly displayed

--

QA-test:

Demo-test:

Download artifact URL:

Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.41.0-pr-789-b5b1-b5b138f2.zip