### PR TITLE
ci: disable second sonar scan

### DIFF
--- a/.github/workflows/storybook-ci.yml
+++ b/.github/workflows/storybook-ci.yml
@@ -35,7 +35,6 @@ jobs:
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
       CLIENT_ID: ${{secrets.CLIENT_ID}}
       CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
-      SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
       VERSION_SUFFIX: ''
@@ -97,12 +96,6 @@ jobs:
           yarn install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build
         run: |


### PR DESCRIPTION
## Description
Don't run Sonar Scan twice (second time during Storybook CI) because:
1. We run both Theme CI and Storybook CI for all files
2. It causes error `Please retry analysis of this Pull-Request directly on SonarCloud`.

## References
### QA-test:
### Jira-link:
### Artifact URL:
