### PR TITLE
fix: proceed to payment step when selected only digital products at mixed cart

### DIFF
--- a/client-app/shared/cart/composables/useCart.ts
+++ b/client-app/shared/cart/composables/useCart.ts
@@ -67,7 +67,10 @@ const availablePaymentMethods = computed<PaymentMethodType[]>(() => cart.value?.
 const lineItemsGroupedByVendor = computed(() => getLineItemsGroupedByVendor(cart.value?.items ?? []));
 
 const allItemsAreDigital = computed<boolean>(
-  () => !!cart.value?.items?.every((item) => item.productType === ProductType.Digital),
+  () =>
+    !!cart.value?.items
+      ?.filter((item) => item.selectedForCheckout)
+      .every((item) => item.productType === ProductType.Digital),
 );
 
 const addedGiftsByIds = computed(() => keyBy(cart.value?.gifts, "id"));


### PR DESCRIPTION
## Description

Proceed to the checkout payment step when only digital products are selected at mixed cart (contains digital and physical products)

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/ST-5085

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.42.0-pr-824-3afc-3afcd34f.zip