### PR TITLE
fix: make create quote button width same as palce order button

### DIFF
--- a/client-app/pages/cart.vue
+++ b/client-app/pages/cart.vue
@@ -154,7 +154,7 @@
             {{ $t("common.messages.quote_request") }}
           </p>
 
-          <VcButton :disabled="loading" :loading="creatingQuote" variant="outline" @click="createQuote">
+          <VcButton :disabled="loading" :loading="creatingQuote" full-width variant="outline" @click="createQuote">
             {{ $t("common.buttons.create_quote") }}
           </VcButton>
         </VcCardWidget>


### PR DESCRIPTION
## Description

Make "Add cart items to quote" button width same as "Place order" button

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/ST-5114

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.42.0-pr-825-b4be-b4be2676.zip