### PR TITLE
fix: save wishlist with deleted products

### DIFF
--- a/client-app/pages/account/list-details.vue
+++ b/client-app/pages/account/list-details.vue
@@ -199,10 +199,12 @@ async function addAllListItemsToCart(): Promise<void> {
 async function updateItems() {
   const payload: InputUpdateWishlistItemsType = {
     listId: list.value!.id!,
-    items: wishlistItems.value!.map<InputUpdateWishlistLineItemType>((item) => ({
-      lineItemId: item.id,
-      quantity: item.quantity!,
-    })),
+    items: wishlistItems
+      .value!.filter((el) => !!el.product)
+      .map<InputUpdateWishlistLineItemType>((item) => ({
+        lineItemId: item.id,
+        quantity: item.quantity!,
+      })),
   };
   await updateItemsInWishlist(payload);
 }


### PR DESCRIPTION
## Description
The Save Changes feature does not work for wish lists that have deleted products. After this fix items with deleted products will no linger involve in the save operation

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/ST-5077
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.42.0-pr-827-c4d4-c4d4fa49.zip
