### PR TITLE
fix: remove empty page in print mode

### DIFF
--- a/client-app/App.vue
+++ b/client-app/App.vue
@@ -3,8 +3,6 @@
     <link rel="icon" :href="$cfg.favicon_image" />
   </Head>
 
-  <body class="font-lato" />
-
   <component :is="layout">
     <RouterView />
   </component>


### PR DESCRIPTION
## Description
[Print Order] The empty page is added if there are 2 vendor sections and 4 items in Order

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/ST-5131
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.42.0-pr-834-34b3-34b3e440.zip
