### PR TITLE
feat: Google Analytics. Add related search term to "select_item" event in search bar item

### DIFF
--- a/client-app/shared/layout/components/search-bar/search-bar.vue
+++ b/client-app/shared/layout/components/search-bar/search-bar.vue
@@ -96,7 +96,7 @@
                 :product="product"
                 @link-click="
                   hideSearchDropdown();
-                  ga.selectItem(product);
+                  ga.selectItem(product, { search_term: searchPhrase.trim() });
                 "
               />
             </div>


### PR DESCRIPTION
## Description
Now when we click on a product in the list, we send a select_item event and put the product there.
In such situations, marketers are asked to add the phrase by which this product was found.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/ST-5421
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.43.0-pr-854-fc36-fc36249b.zip
