### PR TITLE
chore: cleanup cache on checkout & run hooks with yarn

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
-npx --no-install commitlint --edit "$1"
+yarn commitlint ${1}

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+test -d node_modules/.cache && rm -r node_modules/.cache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint-staged
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "validate:types": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "validate:dependencies": "depcruise client-app",
     "validate": "yarn validate:types && yarn validate:dependencies",
+    "commitlint": "commitlint --edit",
     "lint-staged": "lint-staged",
     "lint": "eslint . --ext .js,.ts,.vue --ignore-path .eslintignore",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
## Description
* Added git hook (via husky) to cleanup cache after checkout. Should help for linter false-positives when switch between branches
* Other hooks moved to use yarn without temporary packages installation (will took package from `node_modules`). Should a little bit speed up commit linting
## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
