### PR TITLE
chore: add linter rules for apollo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -179,6 +179,13 @@ module.exports = {
       files: ["*.ts"],
       excludedFiles: ["./*.js", "./*.ts", "**/components/**/index.ts", "*.stories.ts", "shims-*.d.ts"],
       rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            name: "@apollo/client",
+            message: "@apollo/client is for React only. Please import from @apollo/client/* or @vue/apollo-composable"
+          }
+        ],
         "no-restricted-exports": [
           "warn",
           {


### PR DESCRIPTION
## Description
Since the `@apollo/client` depends on React and include React hooks, you should never import it and instead import sub packages `@apollo/client/*` or use composables from `@vue/apollo-composable`
## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/ST-5488
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.44.0-pr-870-28dc-28dcba82.zip
