### PR TITLE
fix: show Invite sent status for Invited xapi contact status

### DIFF
--- a/client-app/shared/company/types/index.ts
+++ b/client-app/shared/company/types/index.ts
@@ -9,6 +9,7 @@ export enum ContactStatus {
   Rejected = "Rejected",
   Locked = "Locked",
   Deleted = "Deleted",
+  Invited = "Invited",
 }
 
 export type ContactDisplayStatusType = {

--- a/client-app/shared/company/utils/index.ts
+++ b/client-app/shared/company/utils/index.ts
@@ -53,7 +53,8 @@ export function convertToExtendedContact(contact: ContactType, fullNameFallback:
 
   return {
     ...contact,
-    fullName: contact.status ? contactFullName : fullNameFallback,
+    fullName:
+      contact.status && contact.status !== ContactStatus.Invited.toString() ? contactFullName : fullNameFallback,
     extended: {
       roles: getContactRoles(contact),
       emails: getContactEmailAddresses(contact),


### PR DESCRIPTION
## Description

Show "Invite sent" status at company members page for Invited xapi contact status

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/ST-5568

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.45.0-pr-889-668f-668fc902.zip