### PR TITLE
fix: latest orders padding on dashboard

### DIFF
--- a/client-app/shared/account/components/orders.vue
+++ b/client-app/shared/account/components/orders.vue
@@ -121,6 +121,7 @@
         ? $t('pages.account.orders.no_results_message')
         : $t('pages.account.orders.no_orders_message')
     "
+    class="py-8"
   >
     <template #icon>
       <VcImage src="/static/images/common/order.svg" :alt="$t('pages.account.orders.no_orders_img_alt')" />


### PR DESCRIPTION
## Description

Fix latest orders padding on dashboard

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/ST-5386

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.47.0-pr-923-53f5-53f542e0.zip