### PR TITLE
fix: show unexisting or empty properties values as dashes at compare products page

### DIFF
--- a/client-app/core/utilities/properties/index.ts
+++ b/client-app/core/utilities/properties/index.ts
@@ -18,7 +18,7 @@ export function getPropertyValue(property: Property): string {
       return n(property.value);
 
     default:
-      return String(property.value);
+      return String(property.value ?? "-");
   }
 }
 

--- a/client-app/core/utilities/properties/index.ts
+++ b/client-app/core/utilities/properties/index.ts
@@ -3,7 +3,7 @@ import { PropertyValueType } from "../../enums";
 import type { PropertyType } from "../../enums";
 import type { Property } from "@/core/api/graphql/types";
 
-export function getPropertyValue(property: Property): string {
+export function getPropertyValue(property: Property): string | null | undefined {
   const { t, d, n } = globals.i18n.global;
 
   switch (property.valueType) {
@@ -18,7 +18,7 @@ export function getPropertyValue(property: Property): string {
       return n(property.value);
 
     default:
-      return String(property.value ?? "-");
+      return property.value;
   }
 }
 
@@ -33,7 +33,7 @@ export function getPropertiesGroupedByName(items: Property[], type?: PropertyTyp
       return propertiesByName;
     }
 
-    const value: string = getPropertyValue(item);
+    const value: string | null | undefined = getPropertyValue(item);
 
     if (propertiesByName[item.name]) {
       propertiesByName[item.name].value += `, ${value}`;

--- a/client-app/pages/compare-products.vue
+++ b/client-app/pages/compare-products.vue
@@ -165,7 +165,7 @@ function getProperties() {
       values: _.map(products.value, (product) => {
         const property = _.find(product.properties, ["name", name]);
 
-        return property ? getPropertyValue(property) : "\u2013";
+        return property ? getPropertyValue(property) ?? "\u2013" : "\u2013";
       }),
     };
   });


### PR DESCRIPTION
## Description

Show unexisting or empty properties values as dashes at compare products page

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/ST-5355

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.48.0-pr-927-475d-475da834.zip