### PR TITLE
chore: use takeover mode instead of vue typescript plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,13 +8,13 @@
     "esbenp.prettier-vscode",
     "bradlc.vscode-tailwindcss",
     "vue.volar",
-    "vue.vscode-typescript-vue-plugin",
     "lokalise.i18n-ally",
     "graphql.vscode-graphql",
     "graphql.vscode-graphql-syntax",
     "graphql.vscode-graphql-execution"
   ],
   "unwantedRecommendations": [
+    "vue.vscode-typescript-vue-plugin",
     "octref.vetur"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ cd C:\vc-storefront\VirtoCommerce.Storefront\VirtoCommerce.Storefront\wwwroot\cm
 yarn install
 ```
 
+#### If you use Visual Studio Code
+1. Setup recommended extensions
+2. Configure [Volar Takeover mode](https://vuejs.org/guide/typescript/overview#volar-takeover-mode)
+
 #### Compile and Hot-Reload for Development
 
 - Open the **.env** file in a text editor


### PR DESCRIPTION
## Description
Use [Volar Takeover mode](https://vuejs.org/guide/typescript/overview#volar-takeover-mode) instead
## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.48.0-pr-935-6691-6691c5a0.zip
