### PR TITLE
fix: add vertical aligns for long text with icons in vc-button

### DIFF
--- a/client-app/pages/checkout/completed.vue
+++ b/client-app/pages/checkout/completed.vue
@@ -27,12 +27,12 @@
             <VcButton
               :to="{ name: 'OrderDetails', params: { orderId: placedOrder?.id } }"
               prepend-icon="document-text"
-              class="flex-1"
+              class="!flex flex-1 items-center justify-center"
             >
               {{ $t("common.buttons.show_order") }}
             </VcButton>
 
-            <VcButton to="/" class="flex-1">
+            <VcButton to="/" class="!flex flex-1 items-center justify-center">
               {{ $t("common.buttons.home") }}
             </VcButton>
           </div>

--- a/client-app/ui-kit/components/molecules/button/vc-button.vue
+++ b/client-app/ui-kit/components/molecules/button/vc-button.vue
@@ -277,8 +277,8 @@ const attrs = computed(() => {
     }
 
     &--outline--#{$color} {
-      @apply bg-[--color-additional-50] 
-      text-[--color-#{$color}-500] 
+      @apply bg-[--color-additional-50]
+      text-[--color-#{$color}-500]
       border-current;
 
       &:hover {
@@ -330,6 +330,7 @@ const attrs = computed(() => {
 
   &__prepend {
     $prepend: &;
+    @apply my-auto;
 
     &:empty {
       @apply hidden;
@@ -338,6 +339,7 @@ const attrs = computed(() => {
 
   &__append {
     $append: &;
+    @apply my-auto;
 
     &:empty {
       @apply hidden;


### PR DESCRIPTION
## Description
![image](https://github.com/VirtoCommerce/vc-theme-b2b-vue/assets/19205780/79e4e3fe-012c-4589-8a1f-efdda51a3a6e)
![image](https://github.com/VirtoCommerce/vc-theme-b2b-vue/assets/19205780/7d6c219c-de2e-4736-b243-0e7c289b6bc6)

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-151
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.49.0-pr-940-8815-88156b56.zip
