### PR TITLE
chore: don't run linter on merge commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-yarn lint-staged
+if [ -z $(git rev-parse -q --verify MERGE_HEAD) ]; then
+  yarn lint-staged
+fi


### PR DESCRIPTION
## Description
Before this PR linter run at merge conflicts and may cause unexpected changes if for some reason not all files in project was linted.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-465
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.50.0-pr-956-5ed4-5ed4f284.zip
