### PR TITLE
feat: support case-insensitive file extensions on file upload

### DIFF
--- a/client-app/shared/files/composables/useFiles.ts
+++ b/client-app/shared/files/composables/useFiles.ts
@@ -104,7 +104,7 @@ export function useFiles(scope: MaybeRef<string>, initialValue?: WatchSource<IAt
         extension &&
         !options.value.allowedExtensions.map((item) => item.toLowerCase()).includes(extension)
       ) {
-        toFailedFile(newFile, getErrorMessage("INVALID_EXTENSION", options.value.allowedExtensions));
+        toFailedFile(newFile, getErrorMessage("INVALID_EXTENSION"));
       }
     });
   }
@@ -160,8 +160,6 @@ export function useFiles(scope: MaybeRef<string>, initialValue?: WatchSource<IAt
           unitDisplay: "narrow",
         }),
       ];
-    } else if (errorCode === "INVALID_EXTENSION") {
-      parameters = [(errorParameter as string[]).map((el) => el.replace(/^\./, "").toUpperCase()).join(", ")];
     } else {
       parameters = [errorParameter as string];
     }

--- a/client-app/shared/files/composables/useFiles.ts
+++ b/client-app/shared/files/composables/useFiles.ts
@@ -98,8 +98,12 @@ export function useFiles(scope: MaybeRef<string>, initialValue?: WatchSource<IAt
         toFailedFile(newFile, getErrorMessage("INVALID_SIZE", options.value.maxFileSize));
       }
 
-      const extension = /(\.[^.]+)?$/.exec(newFile.name)?.[1];
-      if (options.value.allowedExtensions.length && extension && !options.value.allowedExtensions.includes(extension)) {
+      const extension = /(\.[^.]+)?$/.exec(newFile.name)?.[1]?.toLowerCase();
+      if (
+        options.value.allowedExtensions.length &&
+        extension &&
+        !options.value.allowedExtensions.map((item) => item.toLowerCase()).includes(extension)
+      ) {
         toFailedFile(newFile, getErrorMessage("INVALID_EXTENSION", options.value.allowedExtensions));
       }
     });

--- a/locales/en.json
+++ b/locales/en.json
@@ -1401,7 +1401,7 @@
     "INVALID_CONTENT": "Cannot read file.",
     "EXCEPTION": "Failure while uploading file. Please try again.",
     "INVALID_SCOPE": "Unknown scope '{0}'.",
-    "INVALID_EXTENSION": "File is not in one of allowed formats {0}.",
+    "INVALID_EXTENSION": "File format is not allowed.",
     "INVALID_SIZE": "File size exceeds the allowed {0}.",
     "CANNOT_DELETE": "Failure while deleting file."
   }


### PR DESCRIPTION
## Description

Support case-insensitive file extensions on file upload

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-537

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.52.0-pr-973-5303-530355f2.zip