### PR TITLE
fix: prevent drag and drop file opening if file limit exceeded

### DIFF
--- a/client-app/ui-kit/components/molecules/file-uploader/vc-file-uploader.vue
+++ b/client-app/ui-kit/components/molecules/file-uploader/vc-file-uploader.vue
@@ -20,7 +20,6 @@
     <button
       type="button"
       class="vc-file-uploader__drop-container"
-      :class="{ 'vc-file-uploader__drop-container--disabled': hasMaxFileCount }"
       @dragover.prevent
       @dragenter.prevent
       @drop="onFileDrop"

--- a/client-app/ui-kit/components/molecules/file-uploader/vc-file-uploader.vue
+++ b/client-app/ui-kit/components/molecules/file-uploader/vc-file-uploader.vue
@@ -51,7 +51,7 @@
       size="sm"
       icon
     >
-      <template v-if="hasMaxFileCount">
+      <template v-if="hasMaxFileCount && !triedMoreThanMaxFileCount">
         {{ $t("ui_kit.file_uploader.errors.has_max_file_count") }}
       </template>
       <template v-if="triedMoreThanMaxFileCount">
@@ -100,7 +100,7 @@ const { t, n } = useI18n();
 
 const fileInputRef = ref<HTMLInputElement>();
 
-const hasMaxFileCount = computed<boolean>(() => props.files.length >= props.maxFileCount);
+const hasMaxFileCount = computed<boolean>(() => props.files.length === props.maxFileCount);
 
 const triedMoreThanMaxFileCount = ref<boolean>();
 


### PR DESCRIPTION
## Description

Prevent file upload or opening if file limit exceeded on drag and drop

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-462

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.54.0-pr-983-010b-010b54b9.zip
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.52.0-pr-983-8051-80516b6c.zip