### PR TITLE
chore: visualize dependency graph from X to Y

### DIFF
--- a/.dependency-graph.cjs
+++ b/.dependency-graph.cjs
@@ -1,0 +1,9 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  extends: "./.dependency-cruiser.cjs",
+  options: {
+    exclude: {
+      dynamic: true
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate:graphql:types": "graphql-codegen --config graphql-codegen.types.config.ts --require ./scripts/graphql-codegen.cjs",
     "generate:graphql": "yarn generate:graphql:schema && yarn generate:graphql:types",
     "generate:routes": "vite-node --mode production scripts/generate-routes.ts",
-    "generate:dependency-graph": "depcruise client-app --output-type dot | dot -T svg | depcruise-wrap-stream-in-html > artifacts/dependency-graph.html",
+    "generate:dependency-graph": "depcruise $0 --focus $0 --focus-depth 0 --reaches $1 --config .dependency-graph.cjs --output-type dot | dot -T svg | depcruise-wrap-stream-in-html > artifacts/dependency-graph.html",
     "storybook:dev": "yarn generate:certificates && storybook dev --port 6006 --no-open --https --ssl-cert ./.certificates/public.pem --ssl-key ./.certificates/private.pem",
     "storybook:build": "storybook build",
     "storybook:compress": "vite-node --mode production scripts/compress-storybook.ts --",


### PR DESCRIPTION
## Description
How to use:
```bash
yarn generate:dependency-graph FROM TO
```

For example, to see why `add-to-wishlist-modal.vue` is added to main bundle, use this:
```
yarn generate:dependency-graph client-app/main.ts client-app/shared/wishlists/components/add-to-wishlists-modal.vue
```
Current dev:
![image](https://github.com/VirtoCommerce/vc-theme-b2b-vue/assets/6369252/3cff6d00-22bc-4a71-8ef4-87fd4b398d57)
[dev.zip](https://github.com/VirtoCommerce/vc-theme-b2b-vue/files/14454808/dev.zip)

After some refactoring:
![image](https://github.com/VirtoCommerce/vc-theme-b2b-vue/assets/6369252/98137bfe-2f1f-4302-8eca-ec0f16f8953a)
[refactoring.zip](https://github.com/VirtoCommerce/vc-theme-b2b-vue/files/14454812/refactoring.zip)

Useful with #989: just look from `client-app/main.ts` to largest files included to bundle and replace imports via `index.ts` by direct imports.

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.52.0-pr-990-feae-feae036b.zip
