### PR TITLE
fix: don't reexport from ui-kit

### DIFF
--- a/client-app/shared/files/composables/useFiles.ts
+++ b/client-app/shared/files/composables/useFiles.ts
@@ -18,7 +18,7 @@ import {
   toRemovedFile,
   toUploadedFile,
   toUploadingFile,
-} from "@/ui-kit";
+} from "@/ui-kit/utilities";
 import type { FileUploadResultType, IFileOptions } from "@/shared/files/types";
 import type { AxiosProgressEvent, AxiosResponse } from "axios";
 import type { MaybeRef, WatchSource } from "vue";

--- a/client-app/ui-kit/index.ts
+++ b/client-app/ui-kit/index.ts
@@ -26,7 +26,3 @@ export const uiKit: Plugin = {
     app.use(VueSecureHTML);
   },
 };
-
-export * from "./composables";
-export * from "./constants";
-export * from "./utilities";


### PR DESCRIPTION
## Description
Composables, constants & utils import of `ui-kit/index.ts` may cause build failures like [this](https://github.com/VirtoCommerce/vc-theme-b2b-vue/actions/runs/8060523377/job/22017841531) because of `routes.json` generation.

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.52.0-pr-991-dd49-dd49a01b.zip
