### PR TITLE
chore: generate graphql types from downloaded schema

### DIFF
--- a/client-app/core/api/graphql/schema.json
+++ b/client-app/core/api/graphql/schema.json
@@ -11,9 +11,11 @@
       {
         "kind": "OBJECT",
         "name": "AccountCreationResultType",
+        "description": null,
         "fields": [
           {
             "name": "errors",
+            "description": "The errors that occurred during the operation.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -29,6 +31,7 @@
           },
           {
             "name": "requireEmailVerification",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -44,6 +47,7 @@
           },
           {
             "name": "succeeded",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -66,10 +70,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "AddAddressToFavoritesCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -91,10 +97,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "AddQuoteAttachmentsCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -110,6 +118,7 @@
           },
           {
             "name": "urls",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -135,9 +144,11 @@
       {
         "kind": "OBJECT",
         "name": "Asset",
+        "description": null,
         "fields": [
           {
             "name": "cultureName",
+            "description": "Culture name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -149,6 +160,7 @@
           },
           {
             "name": "group",
+            "description": "Group of the asset.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -160,6 +172,7 @@
           },
           {
             "name": "id",
+            "description": "The unique ID of the asset.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -175,6 +188,7 @@
           },
           {
             "name": "mimeType",
+            "description": "MimeType of the asset.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -186,6 +200,7 @@
           },
           {
             "name": "name",
+            "description": "The name of the asset.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -197,6 +212,7 @@
           },
           {
             "name": "relativeUrl",
+            "description": "RelativeUrl of the asset.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -208,6 +224,7 @@
           },
           {
             "name": "size",
+            "description": "Size of the asset.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -223,6 +240,7 @@
           },
           {
             "name": "typeId",
+            "description": "Type id of the asset.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -238,6 +256,7 @@
           },
           {
             "name": "url",
+            "description": "Url of the asset.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -260,9 +279,11 @@
       {
         "kind": "OBJECT",
         "name": "AuthorizePaymentResultType",
+        "description": null,
         "fields": [
           {
             "name": "errorMessage",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -274,6 +295,7 @@
           },
           {
             "name": "isSuccess",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -296,9 +318,11 @@
       {
         "kind": "OBJECT",
         "name": "AvailabilityData",
+        "description": null,
         "fields": [
           {
             "name": "availableQuantity",
+            "description": "Available quantity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -314,6 +338,7 @@
           },
           {
             "name": "inventories",
+            "description": "Inventories",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -337,6 +362,7 @@
           },
           {
             "name": "isActive",
+            "description": "Is active",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -352,6 +378,7 @@
           },
           {
             "name": "isAvailable",
+            "description": "Is available",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -367,6 +394,7 @@
           },
           {
             "name": "isBuyable",
+            "description": "Is buyable",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -382,6 +410,7 @@
           },
           {
             "name": "isEstimated",
+            "description": "Is estimated",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -397,6 +426,7 @@
           },
           {
             "name": "isInStock",
+            "description": "Is in stock",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -412,6 +442,7 @@
           },
           {
             "name": "isTrackInventory",
+            "description": "Is track inventory",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -434,6 +465,7 @@
       {
         "kind": "SCALAR",
         "name": "Boolean",
+        "description": "The `Boolean` scalar type represents `true` or `false`.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -443,9 +475,11 @@
       {
         "kind": "OBJECT",
         "name": "Breadcrumb",
+        "description": null,
         "fields": [
           {
             "name": "itemId",
+            "description": "Id of item the breadcrumb calculated for",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -461,6 +495,7 @@
           },
           {
             "name": "semanticUrl",
+            "description": "Semantic URL keyword",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -472,6 +507,7 @@
           },
           {
             "name": "seoPath",
+            "description": "Full path from catalog",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -483,6 +519,7 @@
           },
           {
             "name": "title",
+            "description": "Name of current breadcrumb",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -498,6 +535,7 @@
           },
           {
             "name": "typeName",
+            "description": "Catalog, category or product",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -520,9 +558,11 @@
       {
         "kind": "OBJECT",
         "name": "BulkCartType",
+        "description": null,
         "fields": [
           {
             "name": "cart",
+            "description": "Cart",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -534,6 +574,7 @@
           },
           {
             "name": "errors",
+            "description": "A set of errors in case the Skus are invalid",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -556,9 +597,11 @@
       {
         "kind": "OBJECT",
         "name": "BulkWishlistType",
+        "description": null,
         "fields": [
           {
             "name": "wishlists",
+            "description": "Wishlists",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -581,10 +624,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "CancelQuoteCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "comment",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -600,6 +645,7 @@
           },
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -621,9 +667,11 @@
       {
         "kind": "OBJECT",
         "name": "CartAddressType",
+        "description": null,
         "fields": [
           {
             "name": "addressType",
+            "description": "Address type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -635,6 +683,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -646,6 +695,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -657,6 +707,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -668,6 +719,7 @@
           },
           {
             "name": "description",
+            "description": "Description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -679,6 +731,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -690,6 +743,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -701,6 +755,7 @@
           },
           {
             "name": "id",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -712,6 +767,7 @@
           },
           {
             "name": "key",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -723,6 +779,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -734,6 +791,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -745,6 +803,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -756,6 +815,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -767,6 +827,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -778,6 +839,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -789,6 +851,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -800,6 +863,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -811,6 +875,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -826,6 +891,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -837,6 +903,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -848,6 +915,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -866,9 +934,11 @@
       {
         "kind": "OBJECT",
         "name": "CartConnection",
+        "description": "A connection from an object to a list of objects of type `Cart`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -884,6 +954,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -899,6 +970,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -914,6 +986,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -932,9 +1005,11 @@
       {
         "kind": "OBJECT",
         "name": "CartEdge",
+        "description": "An edge in a connection from an object to another object of type `Cart`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -950,6 +1025,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -968,9 +1044,11 @@
       {
         "kind": "OBJECT",
         "name": "CartShipmentItemType",
+        "description": null,
         "fields": [
           {
             "name": "lineItem",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -982,6 +1060,7 @@
           },
           {
             "name": "quantity",
+            "description": "Quantity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1004,9 +1083,11 @@
       {
         "kind": "OBJECT",
         "name": "CartType",
+        "description": null,
         "fields": [
           {
             "name": "addresses",
+            "description": "Addresses",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1030,6 +1111,7 @@
           },
           {
             "name": "availableGifts",
+            "description": "Available Gifts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1053,6 +1135,7 @@
           },
           {
             "name": "availablePaymentMethods",
+            "description": "Available payment methods",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1076,6 +1159,7 @@
           },
           {
             "name": "availableShippingMethods",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1099,6 +1183,7 @@
           },
           {
             "name": "channelId",
+            "description": "Shopping cart channel ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1110,6 +1195,7 @@
           },
           {
             "name": "comment",
+            "description": "Shopping cart text comment",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1121,6 +1207,7 @@
           },
           {
             "name": "coupons",
+            "description": "Coupons",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1144,6 +1231,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1159,6 +1247,7 @@
           },
           {
             "name": "customerId",
+            "description": "Shopping cart user ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1174,6 +1263,7 @@
           },
           {
             "name": "customerName",
+            "description": "Shopping cart user name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1185,6 +1275,7 @@
           },
           {
             "name": "discountTotal",
+            "description": "Total discount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1200,6 +1291,7 @@
           },
           {
             "name": "discountTotalWithTax",
+            "description": "Total discount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1215,6 +1307,7 @@
           },
           {
             "name": "discounts",
+            "description": "Discounts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1238,9 +1331,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Cart dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1273,6 +1368,7 @@
           },
           {
             "name": "extendedPriceTotal",
+            "description": "Total extended price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1288,6 +1384,7 @@
           },
           {
             "name": "extendedPriceTotalWithTax",
+            "description": "Total extended price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1303,6 +1400,7 @@
           },
           {
             "name": "fee",
+            "description": "Shopping cart fee",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1318,6 +1416,7 @@
           },
           {
             "name": "feeTotal",
+            "description": "Total fee",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1333,6 +1432,7 @@
           },
           {
             "name": "feeTotalWithTax",
+            "description": "Total fee with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1348,6 +1448,7 @@
           },
           {
             "name": "feeWithTax",
+            "description": "Shopping cart fee with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1363,6 +1464,7 @@
           },
           {
             "name": "gifts",
+            "description": "Gifts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1386,6 +1488,7 @@
           },
           {
             "name": "handlingTotal",
+            "description": "Total handling",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1401,6 +1504,7 @@
           },
           {
             "name": "handlingTotalWithTax",
+            "description": "Total handling with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1416,6 +1520,7 @@
           },
           {
             "name": "hasPhysicalProducts",
+            "description": "Has physical products",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1427,6 +1532,7 @@
           },
           {
             "name": "id",
+            "description": "Shopping cart ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1442,6 +1548,7 @@
           },
           {
             "name": "isAnonymous",
+            "description": "Displays whether the shopping cart is anonymous",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1457,6 +1564,7 @@
           },
           {
             "name": "isRecuring",
+            "description": "Displays whether the shopping cart is recurring",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1468,9 +1576,11 @@
           },
           {
             "name": "isValid",
+            "description": "Shows whether the cart is valid",
             "args": [
               {
                 "name": "ruleSet",
+                "description": "CartValidator's rule sets to call. One of or comma-divided combination of \"items\",\"shipments\",\"payments\"",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1495,6 +1605,7 @@
           },
           {
             "name": "items",
+            "description": "Items",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1518,6 +1629,7 @@
           },
           {
             "name": "itemsCount",
+            "description": "Item count",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1533,6 +1645,7 @@
           },
           {
             "name": "itemsQuantity",
+            "description": "Quantity of items",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1548,6 +1661,7 @@
           },
           {
             "name": "name",
+            "description": "Shopping cart name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1563,6 +1677,7 @@
           },
           {
             "name": "organizationId",
+            "description": "Shopping cart organization ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1574,6 +1689,7 @@
           },
           {
             "name": "organizationName",
+            "description": "Shopping cart organization name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1585,6 +1701,7 @@
           },
           {
             "name": "paymentPrice",
+            "description": "Payment price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1600,6 +1717,7 @@
           },
           {
             "name": "paymentPriceWithTax",
+            "description": "Payment price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1615,6 +1733,7 @@
           },
           {
             "name": "paymentTotal",
+            "description": "Total payment",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1630,6 +1749,7 @@
           },
           {
             "name": "paymentTotalWithTax",
+            "description": "Total payment with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1645,6 +1765,7 @@
           },
           {
             "name": "payments",
+            "description": "Payments",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1668,6 +1789,7 @@
           },
           {
             "name": "purchaseOrderNumber",
+            "description": "Purchase order number",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1679,6 +1801,7 @@
           },
           {
             "name": "shipments",
+            "description": "Shipments",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1702,6 +1825,7 @@
           },
           {
             "name": "shippingPrice",
+            "description": "Shipping price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1717,6 +1841,7 @@
           },
           {
             "name": "shippingPriceWithTax",
+            "description": "Shipping price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1732,6 +1857,7 @@
           },
           {
             "name": "shippingTotal",
+            "description": "Total shipping",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1747,6 +1873,7 @@
           },
           {
             "name": "shippingTotalWithTax",
+            "description": "Total shipping with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1762,6 +1889,7 @@
           },
           {
             "name": "status",
+            "description": "Shopping cart status",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1773,6 +1901,7 @@
           },
           {
             "name": "storeId",
+            "description": "Shopping cart store ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1788,6 +1917,7 @@
           },
           {
             "name": "subTotal",
+            "description": "Shopping cart subtotal",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1803,6 +1933,7 @@
           },
           {
             "name": "subTotalDiscount",
+            "description": "Subtotal discount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1818,6 +1949,7 @@
           },
           {
             "name": "subTotalDiscountWithTax",
+            "description": "Subtotal discount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1833,6 +1965,7 @@
           },
           {
             "name": "subTotalWithTax",
+            "description": "Subtotal with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1848,6 +1981,7 @@
           },
           {
             "name": "taxDetails",
+            "description": "Tax details",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1871,6 +2005,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": "Tax percentage",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1886,6 +2021,7 @@
           },
           {
             "name": "taxTotal",
+            "description": "Total tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1901,6 +2037,7 @@
           },
           {
             "name": "taxType",
+            "description": "Shipping tax type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1916,6 +2053,7 @@
           },
           {
             "name": "total",
+            "description": "Shopping cart total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1931,6 +2069,7 @@
           },
           {
             "name": "type",
+            "description": "Shopping cart type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1942,9 +2081,11 @@
           },
           {
             "name": "validationErrors",
+            "description": "A set of errors in case the cart is invalid",
             "args": [
               {
                 "name": "ruleSet",
+                "description": "CartValidator's rule sets to call. One of or comma-divided combination of \"items\",\"shipments\",\"payments\"",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1977,6 +2118,7 @@
           },
           {
             "name": "volumetricWeight",
+            "description": "Shopping cart volumetric weight value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1988,6 +2130,7 @@
           },
           {
             "name": "warnings",
+            "description": "A set of temporary warnings for a cart user",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2011,6 +2154,7 @@
           },
           {
             "name": "weight",
+            "description": "Shopping cart weight value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2022,6 +2166,7 @@
           },
           {
             "name": "weightUnit",
+            "description": "Shopping cart weight unit value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2040,9 +2185,11 @@
       {
         "kind": "OBJECT",
         "name": "CatalogDiscountType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2058,6 +2205,7 @@
           },
           {
             "name": "amountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2073,6 +2221,7 @@
           },
           {
             "name": "coupon",
+            "description": "Coupon",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2084,6 +2233,7 @@
           },
           {
             "name": "description",
+            "description": "Value of discount description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2095,6 +2245,7 @@
           },
           {
             "name": "moneyAmount",
+            "description": "Discount amount in the specified currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2110,6 +2261,7 @@
           },
           {
             "name": "moneyAmountWithTax",
+            "description": "Discount amount with tax in the specified currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2125,6 +2277,7 @@
           },
           {
             "name": "promotion",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -2136,6 +2289,7 @@
           },
           {
             "name": "promotionId",
+            "description": "Value of promotion id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2154,9 +2308,11 @@
       {
         "kind": "OBJECT",
         "name": "Category",
+        "description": null,
         "fields": [
           {
             "name": "breadcrumbs",
+            "description": "Breadcrumbs",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2180,6 +2336,7 @@
           },
           {
             "name": "childCategories",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2203,6 +2360,7 @@
           },
           {
             "name": "code",
+            "description": "SKU of category.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2218,9 +2376,11 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [
               {
                 "name": "type",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -2241,9 +2401,11 @@
           },
           {
             "name": "descriptions",
+            "description": null,
             "args": [
               {
                 "name": "type",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -2276,6 +2438,7 @@
           },
           {
             "name": "hasParent",
+            "description": "Have a parent",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2291,6 +2454,7 @@
           },
           {
             "name": "id",
+            "description": "Id of category.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2306,6 +2470,7 @@
           },
           {
             "name": "images",
+            "description": "Images",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2329,6 +2494,7 @@
           },
           {
             "name": "imgSrc",
+            "description": "The category image.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2340,6 +2506,7 @@
           },
           {
             "name": "level",
+            "description": "Level in hierarchy",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2355,6 +2522,7 @@
           },
           {
             "name": "name",
+            "description": "Name of category.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2370,6 +2538,7 @@
           },
           {
             "name": "outline",
+            "description": "All parent categories ids relative to the requested catalog and concatenated with \\ . E.g. (1/21/344)",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2381,6 +2550,7 @@
           },
           {
             "name": "outlines",
+            "description": "Outlines",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2404,6 +2574,7 @@
           },
           {
             "name": "parent",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -2415,6 +2586,7 @@
           },
           {
             "name": "path",
+            "description": "Category path in to the requested catalog  (all parent categories names concatenated. E.g. (parent1/parent2))",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2426,6 +2598,7 @@
           },
           {
             "name": "priority",
+            "description": "The category priority.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2441,9 +2614,11 @@
           },
           {
             "name": "properties",
+            "description": null,
             "args": [
               {
                 "name": "names",
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -2480,6 +2655,7 @@
           },
           {
             "name": "seoInfo",
+            "description": "Request related SEO info",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2495,6 +2671,7 @@
           },
           {
             "name": "slug",
+            "description": "Request related slug for category",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2513,9 +2690,11 @@
       {
         "kind": "OBJECT",
         "name": "CategoryConnection",
+        "description": "A connection from an object to a list of objects of type `Category`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -2531,6 +2710,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -2546,6 +2726,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2561,6 +2742,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2579,9 +2761,11 @@
       {
         "kind": "OBJECT",
         "name": "CategoryDescriptionType",
+        "description": null,
         "fields": [
           {
             "name": "content",
+            "description": "Description text.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2593,6 +2777,7 @@
           },
           {
             "name": "descriptionType",
+            "description": "Description type.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2604,6 +2789,7 @@
           },
           {
             "name": "id",
+            "description": "Description ID.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2619,6 +2805,7 @@
           },
           {
             "name": "languageCode",
+            "description": "Description language code.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2637,9 +2824,11 @@
       {
         "kind": "OBJECT",
         "name": "CategoryEdge",
+        "description": "An edge in a connection from an object to another object of type `Category`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2655,6 +2844,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -2673,10 +2863,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeQuoteCommentCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "comment",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2692,6 +2884,7 @@
           },
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2713,10 +2906,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ChangeQuoteItemQuantityCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "lineItemId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2732,6 +2927,7 @@
           },
           {
             "name": "quantity",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2747,6 +2943,7 @@
           },
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2768,9 +2965,11 @@
       {
         "kind": "OBJECT",
         "name": "ChildCategoriesQueryResponseType",
+        "description": null,
         "fields": [
           {
             "name": "childCategories",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -2793,9 +2992,11 @@
       {
         "kind": "OBJECT",
         "name": "CommonVendor",
+        "description": null,
         "fields": [
           {
             "name": "id",
+            "description": "Vendor ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2811,6 +3012,7 @@
           },
           {
             "name": "name",
+            "description": "Vendor name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2826,6 +3028,7 @@
           },
           {
             "name": "rating",
+            "description": "Vendor rating",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -2844,9 +3047,11 @@
       {
         "kind": "OBJECT",
         "name": "ContactConnection",
+        "description": "A connection from an object to a list of objects of type `Contact`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -2862,6 +3067,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -2877,6 +3083,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2892,6 +3099,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -2910,9 +3118,11 @@
       {
         "kind": "OBJECT",
         "name": "ContactEdge",
+        "description": "An edge in a connection from an object to another object of type `Contact`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2928,6 +3138,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -2946,9 +3157,11 @@
       {
         "kind": "OBJECT",
         "name": "ContactType",
+        "description": null,
         "fields": [
           {
             "name": "about",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -2964,9 +3177,11 @@
           },
           {
             "name": "addresses",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -2978,6 +3193,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -2989,6 +3205,7 @@
               },
               {
                 "name": "sort",
+                "description": "Sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -3009,6 +3226,7 @@
           },
           {
             "name": "birthDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3020,6 +3238,7 @@
           },
           {
             "name": "defaultBillingAddress",
+            "description": "Default billing address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3031,6 +3250,7 @@
           },
           {
             "name": "defaultShippingAddress",
+            "description": "Default shipping address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3042,9 +3262,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -3073,6 +3295,7 @@
           },
           {
             "name": "emails",
+            "description": "Emails",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3092,6 +3315,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3107,6 +3331,7 @@
           },
           {
             "name": "fullName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3122,6 +3347,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3141,6 +3367,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3156,6 +3383,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3171,6 +3399,7 @@
           },
           {
             "name": "memberType",
+            "description": "Member type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3186,6 +3415,7 @@
           },
           {
             "name": "middleName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3197,6 +3427,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3208,6 +3439,7 @@
           },
           {
             "name": "organizationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3219,9 +3451,11 @@
           },
           {
             "name": "organizations",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -3233,6 +3467,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -3244,6 +3479,7 @@
               },
               {
                 "name": "searchPhrase",
+                "description": "Free text search",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -3255,6 +3491,7 @@
               },
               {
                 "name": "sort",
+                "description": "Sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -3275,6 +3512,7 @@
           },
           {
             "name": "organizationsIds",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3294,6 +3532,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3305,6 +3544,7 @@
           },
           {
             "name": "phones",
+            "description": "Phones",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3324,6 +3564,7 @@
           },
           {
             "name": "securityAccounts",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3339,9 +3580,11 @@
           },
           {
             "name": "seoInfo",
+            "description": "Request related SEO info",
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -3357,6 +3600,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -3381,6 +3625,7 @@
           },
           {
             "name": "seoObjectType",
+            "description": "SEO object type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3396,6 +3641,7 @@
           },
           {
             "name": "status",
+            "description": "Status",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3414,9 +3660,11 @@
       {
         "kind": "OBJECT",
         "name": "ContractConnection",
+        "description": "A connection from an object to a list of objects of type `Contract`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3432,6 +3680,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -3447,6 +3696,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3462,6 +3712,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3480,9 +3731,11 @@
       {
         "kind": "OBJECT",
         "name": "ContractEdge",
+        "description": "An edge in a connection from an object to another object of type `Contract`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3498,6 +3751,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -3516,9 +3770,11 @@
       {
         "kind": "OBJECT",
         "name": "ContractType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3534,6 +3790,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3545,9 +3802,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Contract dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -3572,6 +3831,7 @@
           },
           {
             "name": "endDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3583,6 +3843,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3598,6 +3859,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3613,6 +3875,7 @@
           },
           {
             "name": "startDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3624,6 +3887,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3635,6 +3899,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3646,6 +3911,7 @@
           },
           {
             "name": "vendorId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3664,9 +3930,11 @@
       {
         "kind": "OBJECT",
         "name": "CountryRegionType",
+        "description": null,
         "fields": [
           {
             "name": "id",
+            "description": "Code of country region. For example 'AL'.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3682,6 +3950,7 @@
           },
           {
             "name": "name",
+            "description": "Name of country region. For example 'Alabama'.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3704,9 +3973,11 @@
       {
         "kind": "OBJECT",
         "name": "CountryType",
+        "description": null,
         "fields": [
           {
             "name": "id",
+            "description": "Code of country. For example 'USA'.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3722,6 +3993,7 @@
           },
           {
             "name": "name",
+            "description": "Name of country. For example 'United States of America'.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3737,6 +4009,7 @@
           },
           {
             "name": "regions",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3767,9 +4040,11 @@
       {
         "kind": "OBJECT",
         "name": "CouponType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": "Coupon code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3781,6 +4056,7 @@
           },
           {
             "name": "isAppliedSuccessfully",
+            "description": "Is coupon was applied successfully",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -3803,10 +4079,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "CreateCustomerReviewCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "entityId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3822,6 +4100,7 @@
           },
           {
             "name": "entityName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3837,6 +4116,7 @@
           },
           {
             "name": "entityType",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3852,6 +4132,7 @@
           },
           {
             "name": "rating",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3867,6 +4148,7 @@
           },
           {
             "name": "review",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3882,6 +4164,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3897,6 +4180,7 @@
           },
           {
             "name": "title",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3912,6 +4196,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3927,6 +4212,7 @@
           },
           {
             "name": "userName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3948,10 +4234,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "CreateQuoteCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3967,6 +4255,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3982,6 +4271,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3997,6 +4287,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4018,10 +4309,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "CreateQuoteFromCartCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4037,6 +4330,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4058,9 +4352,11 @@
       {
         "kind": "OBJECT",
         "name": "CurrencyType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": "Currency code may be used ISO 4217",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4076,6 +4372,7 @@
           },
           {
             "name": "cultureName",
+            "description": "Currency English name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4091,6 +4388,7 @@
           },
           {
             "name": "customFormatting",
+            "description": "Currency custom formatting",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4102,6 +4400,7 @@
           },
           {
             "name": "englishName",
+            "description": "Currency English name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4117,6 +4416,7 @@
           },
           {
             "name": "exchangeRate",
+            "description": "Exchange rate",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4132,6 +4432,7 @@
           },
           {
             "name": "symbol",
+            "description": "Symbol",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4154,9 +4455,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomIdentityResultType",
+        "description": null,
         "fields": [
           {
             "name": "errors",
+            "description": "The errors that occurred during the identity operation.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -4172,6 +4475,7 @@
           },
           {
             "name": "succeeded",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4194,9 +4498,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomerOrderConnection",
+        "description": "A connection from an object to a list of objects of type `CustomerOrder`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -4212,6 +4518,7 @@
           },
           {
             "name": "filter_facets",
+            "description": "Filter facets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4235,6 +4542,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -4250,6 +4558,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4265,6 +4574,7 @@
           },
           {
             "name": "range_facets",
+            "description": "Range facets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4288,6 +4598,7 @@
           },
           {
             "name": "term_facets",
+            "description": "Term facets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4311,6 +4622,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4329,9 +4641,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomerOrderEdge",
+        "description": "An edge in a connection from an object to another object of type `CustomerOrder`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4347,6 +4661,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -4365,9 +4680,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomerOrderType",
+        "description": null,
         "fields": [
           {
             "name": "addresses",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4391,6 +4708,7 @@
           },
           {
             "name": "availablePaymentMethods",
+            "description": "Available payment methods",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4414,6 +4732,7 @@
           },
           {
             "name": "cancelReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4425,6 +4744,7 @@
           },
           {
             "name": "cancelledDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4436,6 +4756,7 @@
           },
           {
             "name": "channelId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4447,6 +4768,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4458,6 +4780,7 @@
           },
           {
             "name": "coupons",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4481,6 +4804,7 @@
           },
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4492,6 +4816,7 @@
           },
           {
             "name": "createdDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4507,6 +4832,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4522,6 +4848,7 @@
           },
           {
             "name": "customerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4537,6 +4864,7 @@
           },
           {
             "name": "customerName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4548,6 +4876,7 @@
           },
           {
             "name": "discountAmount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4563,6 +4892,7 @@
           },
           {
             "name": "discountTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4578,6 +4908,7 @@
           },
           {
             "name": "discountTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4593,6 +4924,7 @@
           },
           {
             "name": "discounts",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4616,9 +4948,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Customer order dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4651,6 +4985,7 @@
           },
           {
             "name": "employeeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4662,6 +4997,7 @@
           },
           {
             "name": "employeeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4673,6 +5009,7 @@
           },
           {
             "name": "fee",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4688,6 +5025,7 @@
           },
           {
             "name": "feeTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4703,6 +5041,7 @@
           },
           {
             "name": "feeTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4718,6 +5057,7 @@
           },
           {
             "name": "feeWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4733,6 +5073,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4748,9 +5089,11 @@
           },
           {
             "name": "inPayments",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4762,6 +5105,7 @@
               },
               {
                 "name": "first",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -4773,6 +5117,7 @@
               },
               {
                 "name": "sort",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -4805,6 +5150,7 @@
           },
           {
             "name": "isApproved",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4820,6 +5166,7 @@
           },
           {
             "name": "isCancelled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4835,6 +5182,7 @@
           },
           {
             "name": "isPrototype",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4850,6 +5198,7 @@
           },
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4873,6 +5222,7 @@
           },
           {
             "name": "languageCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4884,6 +5234,7 @@
           },
           {
             "name": "modifiedBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4895,6 +5246,7 @@
           },
           {
             "name": "modifiedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4906,6 +5258,7 @@
           },
           {
             "name": "number",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4921,6 +5274,7 @@
           },
           {
             "name": "objectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4936,6 +5290,7 @@
           },
           {
             "name": "operationType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4951,6 +5306,7 @@
           },
           {
             "name": "organizationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4962,6 +5318,7 @@
           },
           {
             "name": "organizationName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4973,6 +5330,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4984,6 +5342,7 @@
           },
           {
             "name": "parentOperationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4995,6 +5354,7 @@
           },
           {
             "name": "paymentDiscountTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5010,6 +5370,7 @@
           },
           {
             "name": "paymentDiscountTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5025,6 +5386,7 @@
           },
           {
             "name": "paymentSubTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5040,6 +5402,7 @@
           },
           {
             "name": "paymentSubTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5055,6 +5418,7 @@
           },
           {
             "name": "paymentTaxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5070,6 +5434,7 @@
           },
           {
             "name": "paymentTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5085,6 +5450,7 @@
           },
           {
             "name": "paymentTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5100,6 +5466,7 @@
           },
           {
             "name": "purchaseOrderNumber",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5111,6 +5478,7 @@
           },
           {
             "name": "shipments",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5134,6 +5502,7 @@
           },
           {
             "name": "shippingDiscountTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5149,6 +5518,7 @@
           },
           {
             "name": "shippingDiscountTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5164,6 +5534,7 @@
           },
           {
             "name": "shippingSubTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5179,6 +5550,7 @@
           },
           {
             "name": "shippingSubTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5194,6 +5566,7 @@
           },
           {
             "name": "shippingTaxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5209,6 +5582,7 @@
           },
           {
             "name": "shippingTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5224,6 +5598,7 @@
           },
           {
             "name": "shippingTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5239,6 +5614,7 @@
           },
           {
             "name": "shoppingCartId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5250,6 +5626,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5261,6 +5638,7 @@
           },
           {
             "name": "statusDisplayValue",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5272,6 +5650,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5287,6 +5666,7 @@
           },
           {
             "name": "storeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5298,6 +5678,7 @@
           },
           {
             "name": "subTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5313,6 +5694,7 @@
           },
           {
             "name": "subTotalDiscount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5328,6 +5710,7 @@
           },
           {
             "name": "subTotalDiscountWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5343,6 +5726,7 @@
           },
           {
             "name": "subTotalTaxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5358,6 +5742,7 @@
           },
           {
             "name": "subTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5373,6 +5758,7 @@
           },
           {
             "name": "subscriptionId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5384,6 +5770,7 @@
           },
           {
             "name": "subscriptionNumber",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5395,6 +5782,7 @@
           },
           {
             "name": "taxDetails",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5418,6 +5806,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5433,6 +5822,7 @@
           },
           {
             "name": "taxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5448,6 +5838,7 @@
           },
           {
             "name": "taxType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5459,6 +5850,7 @@
           },
           {
             "name": "total",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5481,9 +5873,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomerReview",
+        "description": null,
         "fields": [
           {
             "name": "createdDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5499,6 +5893,7 @@
           },
           {
             "name": "entityId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5514,6 +5909,7 @@
           },
           {
             "name": "entityName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5529,6 +5925,7 @@
           },
           {
             "name": "entityType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5544,6 +5941,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5559,6 +5957,7 @@
           },
           {
             "name": "modifiedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5570,6 +5969,7 @@
           },
           {
             "name": "rating",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5585,6 +5985,7 @@
           },
           {
             "name": "review",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5600,6 +6001,7 @@
           },
           {
             "name": "reviewStatus",
+            "description": null,
             "args": [],
             "type": {
               "kind": "ENUM",
@@ -5611,6 +6013,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5626,6 +6029,7 @@
           },
           {
             "name": "title",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5641,6 +6045,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5656,6 +6061,7 @@
           },
           {
             "name": "userName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5678,9 +6084,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomerReviewConnection",
+        "description": "A connection from an object to a list of objects of type `CustomerReview`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -5696,6 +6104,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -5711,6 +6120,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5726,6 +6136,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5744,9 +6155,11 @@
       {
         "kind": "OBJECT",
         "name": "CustomerReviewEdge",
+        "description": "An edge in a connection from an object to another object of type `CustomerReview`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5762,6 +6175,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -5780,22 +6194,26 @@
       {
         "kind": "ENUM",
         "name": "CustomerReviewStatus",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "APPROVED",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "NEW",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "REJECTED",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -5805,6 +6223,7 @@
       {
         "kind": "SCALAR",
         "name": "Date",
+        "description": "The `Date` scalar type represents a year, month and day in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -5814,6 +6233,7 @@
       {
         "kind": "SCALAR",
         "name": "DateTime",
+        "description": "The `DateTime` scalar type represents a date and time. `DateTime` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -5823,6 +6243,7 @@
       {
         "kind": "SCALAR",
         "name": "Decimal",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -5832,10 +6253,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "DeleteFileCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5857,10 +6280,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "DeleteQuoteAttachmentsCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5876,6 +6301,7 @@
           },
           {
             "name": "urls",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -5901,9 +6327,11 @@
       {
         "kind": "OBJECT",
         "name": "DescriptionType",
+        "description": null,
         "fields": [
           {
             "name": "content",
+            "description": "Description text.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5915,6 +6343,7 @@
           },
           {
             "name": "id",
+            "description": "Description ID.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5930,6 +6359,7 @@
           },
           {
             "name": "languageCode",
+            "description": "Description language code.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5941,6 +6371,7 @@
           },
           {
             "name": "reviewType",
+            "description": "Description type.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -5959,9 +6390,11 @@
       {
         "kind": "OBJECT",
         "name": "DictionaryItemConnection",
+        "description": "A connection from an object to a list of objects of type `DictionaryItem`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -5977,6 +6410,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -5992,6 +6426,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6007,6 +6442,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6025,9 +6461,11 @@
       {
         "kind": "OBJECT",
         "name": "DictionaryItemEdge",
+        "description": "An edge in a connection from an object to another object of type `DictionaryItem`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6043,6 +6481,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -6061,9 +6500,11 @@
       {
         "kind": "OBJECT",
         "name": "DictionaryItemType",
+        "description": null,
         "fields": [
           {
             "name": "id",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6079,6 +6520,7 @@
           },
           {
             "name": "label",
+            "description": "Localized dictionary item value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6090,6 +6532,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6112,9 +6555,11 @@
       {
         "kind": "OBJECT",
         "name": "DiscountType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6130,6 +6575,7 @@
           },
           {
             "name": "amountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6145,6 +6591,7 @@
           },
           {
             "name": "coupon",
+            "description": "Coupon",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6156,6 +6603,7 @@
           },
           {
             "name": "description",
+            "description": "Value of discount description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6167,6 +6615,7 @@
           },
           {
             "name": "moneyAmount",
+            "description": "Discount amount in the specified currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6182,6 +6631,7 @@
           },
           {
             "name": "moneyAmountWithTax",
+            "description": "Discount amount with tax in the specified currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6197,6 +6647,7 @@
           },
           {
             "name": "promotionId",
+            "description": "Value of promotion id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6215,9 +6666,11 @@
       {
         "kind": "OBJECT",
         "name": "DynamicContentItemType",
+        "description": null,
         "fields": [
           {
             "name": "contentType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6233,6 +6686,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6248,9 +6702,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic content dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -6275,6 +6731,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6290,6 +6747,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6305,6 +6763,7 @@
           },
           {
             "name": "priority",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6327,9 +6786,11 @@
       {
         "kind": "OBJECT",
         "name": "DynamicPropertyConnection",
+        "description": "A connection from an object to a list of objects of type `DynamicProperty`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -6345,6 +6806,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -6360,6 +6822,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6375,6 +6838,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6393,9 +6857,11 @@
       {
         "kind": "OBJECT",
         "name": "DynamicPropertyEdge",
+        "description": "An edge in a connection from an object to another object of type `DynamicProperty`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6411,6 +6877,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -6429,12 +6896,15 @@
       {
         "kind": "OBJECT",
         "name": "DynamicPropertyType",
+        "description": null,
         "fields": [
           {
             "name": "dictionaryItems",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -6446,6 +6916,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -6457,6 +6928,7 @@
               },
               {
                 "name": "filter",
+                "description": "",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -6468,6 +6940,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -6479,6 +6952,7 @@
               },
               {
                 "name": "sort",
+                "description": "",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -6499,6 +6973,7 @@
           },
           {
             "name": "displayOrder",
+            "description": "The order for the dynamic property to display",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6510,6 +6985,7 @@
           },
           {
             "name": "dynamicPropertyValueType",
+            "description": "Value type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6525,6 +7001,7 @@
           },
           {
             "name": "id",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6540,6 +7017,7 @@
           },
           {
             "name": "isArray",
+            "description": "Is dynamic property value an array",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6555,6 +7033,7 @@
           },
           {
             "name": "isDictionary",
+            "description": "Is dynamic property value a dictionary",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6570,6 +7049,7 @@
           },
           {
             "name": "isMultilingual",
+            "description": "Is dynamic property value multilingual",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6585,6 +7065,7 @@
           },
           {
             "name": "isRequired",
+            "description": "Is dynamic property value required",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6600,6 +7081,7 @@
           },
           {
             "name": "label",
+            "description": "Localized property name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6611,6 +7093,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6626,6 +7109,7 @@
           },
           {
             "name": "objectType",
+            "description": "Object type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6641,6 +7125,7 @@
           },
           {
             "name": "valueType",
+            "description": "Value type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6663,6 +7148,7 @@
       {
         "kind": "SCALAR",
         "name": "DynamicPropertyValue",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -6672,9 +7158,11 @@
       {
         "kind": "OBJECT",
         "name": "DynamicPropertyValueType",
+        "description": null,
         "fields": [
           {
             "name": "dictionaryItem",
+            "description": "Associated dictionary item",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -6686,6 +7174,7 @@
           },
           {
             "name": "dynamicProperty",
+            "description": "Associated dynamic property",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -6697,6 +7186,7 @@
           },
           {
             "name": "dynamicPropertyValueType",
+            "description": "Value type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6712,6 +7202,7 @@
           },
           {
             "name": "name",
+            "description": "Property name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6723,6 +7214,7 @@
           },
           {
             "name": "value",
+            "description": "Property value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6734,6 +7226,7 @@
           },
           {
             "name": "valueType",
+            "description": "Value type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6756,52 +7249,62 @@
       {
         "kind": "ENUM",
         "name": "DynamicPropertyValueTypes",
+        "description": "Dynamic property value type",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "BOOLEAN",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DATE_TIME",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DECIMAL",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "HTML",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "IMAGE",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INTEGER",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "LONG_TEXT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SHORT_TEXT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UNDEFINED",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -6811,9 +7314,11 @@
       {
         "kind": "OBJECT",
         "name": "ErrorParameterType",
+        "description": null,
         "fields": [
           {
             "name": "key",
+            "description": "key",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6829,6 +7334,7 @@
           },
           {
             "name": "value",
+            "description": "Value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6851,9 +7357,11 @@
       {
         "kind": "OBJECT",
         "name": "EvaluateDynamicContentResultType",
+        "description": null,
         "fields": [
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -6869,6 +7377,7 @@
           },
           {
             "name": "totalCount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6891,9 +7400,11 @@
       {
         "kind": "INTERFACE",
         "name": "Facet",
+        "description": null,
         "fields": [
           {
             "name": "facetType",
+            "description": "Three facet types: Terms, Range, and Filter",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6909,6 +7420,7 @@
           },
           {
             "name": "label",
+            "description": "Localized name of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6924,6 +7436,7 @@
           },
           {
             "name": "name",
+            "description": "The key/name  of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6962,9 +7475,11 @@
       {
         "kind": "OBJECT",
         "name": "FacetRangeType",
+        "description": null,
         "fields": [
           {
             "name": "count",
+            "description": "Amount of products for which the values in a field fall into the specified range",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6980,6 +7495,7 @@
           },
           {
             "name": "from",
+            "description": "The range’s lower endpoint in number format, 0 represents infinity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6995,6 +7511,7 @@
           },
           {
             "name": "fromStr",
+            "description": "The range’s lower endpoint in string format, empty string represents infinity",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7006,6 +7523,7 @@
           },
           {
             "name": "includeFrom",
+            "description": "The flag indicates that From exclusive",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7021,6 +7539,7 @@
           },
           {
             "name": "includeTo",
+            "description": "The flag indicates that To exclusive",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7036,6 +7555,7 @@
           },
           {
             "name": "isSelected",
+            "description": "is selected state",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7051,6 +7571,7 @@
           },
           {
             "name": "label",
+            "description": "Localization label",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7066,6 +7587,7 @@
           },
           {
             "name": "max",
+            "description": "Maximum value among all values contained within the range",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7081,6 +7603,7 @@
           },
           {
             "name": "min",
+            "description": "Minimum value among all values contained within the range",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7096,6 +7619,7 @@
           },
           {
             "name": "to",
+            "description": "The range’s upper endpoint in number format, 0 represents infinity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7111,6 +7635,7 @@
           },
           {
             "name": "toStr",
+            "description": "The range’s upper endpoint in string format, empty string represents infinity",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7122,6 +7647,7 @@
           },
           {
             "name": "total",
+            "description": "Sum of all values contained in the range",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7144,9 +7670,11 @@
       {
         "kind": "OBJECT",
         "name": "FacetTermType",
+        "description": null,
         "fields": [
           {
             "name": "count",
+            "description": "count",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7162,6 +7690,7 @@
           },
           {
             "name": "isSelected",
+            "description": "is selected state",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7177,6 +7706,7 @@
           },
           {
             "name": "label",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7192,6 +7722,7 @@
           },
           {
             "name": "term",
+            "description": "term",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7214,22 +7745,26 @@
       {
         "kind": "ENUM",
         "name": "FacetTypes",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "FILTER",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "RANGE",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "TERMS",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -7239,9 +7774,11 @@
       {
         "kind": "OBJECT",
         "name": "FileUploadScopeOptionsType",
+        "description": null,
         "fields": [
           {
             "name": "allowedExtensions",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7261,6 +7798,7 @@
           },
           {
             "name": "maxFileSize",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7276,6 +7814,7 @@
           },
           {
             "name": "scope",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7298,9 +7837,11 @@
       {
         "kind": "OBJECT",
         "name": "FilterFacet",
+        "description": null,
         "fields": [
           {
             "name": "count",
+            "description": "The number of products matching the value specified in the filter facet expression",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7316,6 +7857,7 @@
           },
           {
             "name": "facetType",
+            "description": "The three types of facets. Terms, Range, Filter",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7331,6 +7873,7 @@
           },
           {
             "name": "label",
+            "description": "Localized name of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7346,6 +7889,7 @@
           },
           {
             "name": "name",
+            "description": "The key/name  of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7374,9 +7918,11 @@
       {
         "kind": "OBJECT",
         "name": "FulfillmentCenterAddressType",
+        "description": null,
         "fields": [
           {
             "name": "addressType",
+            "description": "Address type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7388,6 +7934,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7399,6 +7946,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7410,6 +7958,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7421,6 +7970,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7432,6 +7982,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7443,6 +7994,7 @@
           },
           {
             "name": "id",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7454,6 +8006,7 @@
           },
           {
             "name": "key",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7465,6 +8018,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7476,6 +8030,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7487,6 +8042,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7498,6 +8054,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7509,6 +8066,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7520,6 +8078,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7531,6 +8090,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7542,6 +8102,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7553,6 +8114,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7568,6 +8130,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7579,6 +8142,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7590,6 +8154,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7608,9 +8173,11 @@
       {
         "kind": "OBJECT",
         "name": "FulfillmentCenterConnection",
+        "description": "A connection from an object to a list of objects of type `FulfillmentCenter`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -7626,6 +8193,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -7641,6 +8209,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7656,6 +8225,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7674,9 +8244,11 @@
       {
         "kind": "OBJECT",
         "name": "FulfillmentCenterEdge",
+        "description": "An edge in a connection from an object to another object of type `FulfillmentCenter`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7692,6 +8264,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -7710,9 +8283,11 @@
       {
         "kind": "OBJECT",
         "name": "FulfillmentCenterType",
+        "description": null,
         "fields": [
           {
             "name": "address",
+            "description": "Fulfillment Center address.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -7724,6 +8299,7 @@
           },
           {
             "name": "description",
+            "description": "Fulfillment Center descripion.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7735,6 +8311,7 @@
           },
           {
             "name": "geoLocation",
+            "description": "Fulfillment Center geo location.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7746,6 +8323,7 @@
           },
           {
             "name": "id",
+            "description": "Fulfillment Center ID.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7761,6 +8339,7 @@
           },
           {
             "name": "name",
+            "description": "Fulfillment Center name.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7772,9 +8351,11 @@
           },
           {
             "name": "nearest",
+            "description": "Nearest Fulfillment Centers",
             "args": [
               {
                 "name": "take",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -7799,6 +8380,7 @@
           },
           {
             "name": "outerId",
+            "description": "Fulfillment Center outerId.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7810,6 +8392,7 @@
           },
           {
             "name": "shortDescription",
+            "description": "Fulfillment Center short description.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7828,9 +8411,11 @@
       {
         "kind": "OBJECT",
         "name": "GiftItemType",
+        "description": null,
         "fields": [
           {
             "name": "categoryId",
+            "description": "Product category ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7842,6 +8427,7 @@
           },
           {
             "name": "id",
+            "description": "Artificial ID for this value object",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7857,6 +8443,7 @@
           },
           {
             "name": "imageUrl",
+            "description": "Value of reward image absolute URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7868,6 +8455,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item ID in case there is a gift in the cart. If there is no gift, it stays null",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7879,6 +8467,7 @@
           },
           {
             "name": "measureUnit",
+            "description": "Measurement unit",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7890,6 +8479,7 @@
           },
           {
             "name": "name",
+            "description": "Name of the reward",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7905,6 +8495,7 @@
           },
           {
             "name": "product",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -7916,6 +8507,7 @@
           },
           {
             "name": "productId",
+            "description": "Product ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7927,6 +8519,7 @@
           },
           {
             "name": "promotionId",
+            "description": "Promotion ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7942,6 +8535,7 @@
           },
           {
             "name": "quantity",
+            "description": "Number of gifts in the reward",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7964,9 +8558,11 @@
       {
         "kind": "OBJECT",
         "name": "IdentityErrorInfoType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": "Error code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -7982,6 +8578,7 @@
           },
           {
             "name": "description",
+            "description": "Error description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -7993,6 +8590,7 @@
           },
           {
             "name": "parameter",
+            "description": "Error parameter",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8011,9 +8609,11 @@
       {
         "kind": "OBJECT",
         "name": "IdentityErrorType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8025,6 +8625,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8043,9 +8644,11 @@
       {
         "kind": "OBJECT",
         "name": "IdentityResultType",
+        "description": null,
         "fields": [
           {
             "name": "errors",
+            "description": "The errors that occurred during the identity operation.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -8061,6 +8664,7 @@
           },
           {
             "name": "succeeded",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8083,9 +8687,11 @@
       {
         "kind": "OBJECT",
         "name": "ImageType",
+        "description": null,
         "fields": [
           {
             "name": "cultureName",
+            "description": "Culture name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8097,6 +8703,7 @@
           },
           {
             "name": "group",
+            "description": "Image group",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8108,6 +8715,7 @@
           },
           {
             "name": "id",
+            "description": "Image ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8123,6 +8731,7 @@
           },
           {
             "name": "name",
+            "description": "Image name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8134,6 +8743,7 @@
           },
           {
             "name": "relativeUrl",
+            "description": "Image relative URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8145,6 +8755,7 @@
           },
           {
             "name": "sortOrder",
+            "description": "Sort order",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8160,6 +8771,7 @@
           },
           {
             "name": "url",
+            "description": "Image URL",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8182,9 +8794,11 @@
       {
         "kind": "OBJECT",
         "name": "InitializePaymentResultType",
+        "description": null,
         "fields": [
           {
             "name": "actionHtmlForm",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8196,6 +8810,7 @@
           },
           {
             "name": "actionRedirectUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8207,6 +8822,7 @@
           },
           {
             "name": "errorMessage",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8218,6 +8834,7 @@
           },
           {
             "name": "isSuccess",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8233,6 +8850,7 @@
           },
           {
             "name": "orderId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8244,6 +8862,7 @@
           },
           {
             "name": "orderNumber",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8255,6 +8874,7 @@
           },
           {
             "name": "paymentActionType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8266,6 +8886,7 @@
           },
           {
             "name": "paymentId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8277,6 +8898,7 @@
           },
           {
             "name": "paymentMethodCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8288,6 +8910,7 @@
           },
           {
             "name": "publicParameters",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -8303,6 +8926,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -8321,10 +8945,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddBulkItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8336,6 +8962,7 @@
           },
           {
             "name": "cartItems",
+            "description": "Bulk cart items",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8355,6 +8982,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8366,6 +8994,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8377,6 +9006,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8388,6 +9018,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8399,6 +9030,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8414,6 +9046,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8435,10 +9068,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddCouponType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8450,6 +9085,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8461,6 +9097,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8472,6 +9109,7 @@
           },
           {
             "name": "couponCode",
+            "description": "Coupon code",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8487,6 +9125,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8498,6 +9137,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8509,6 +9149,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8524,6 +9165,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8545,10 +9187,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddGiftItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8560,6 +9204,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8571,6 +9216,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8582,6 +9228,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8593,6 +9240,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8604,6 +9252,7 @@
           },
           {
             "name": "ids",
+            "description": "IDs of gift rewards to add to the cart",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8623,6 +9272,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8638,6 +9288,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8659,10 +9310,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8674,6 +9327,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8685,6 +9339,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8696,6 +9351,7 @@
           },
           {
             "name": "comment",
+            "description": "Comment",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8707,6 +9363,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8718,6 +9375,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8729,6 +9387,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -8744,6 +9403,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "type": {
               "kind": "SCALAR",
               "name": "Decimal",
@@ -8755,6 +9415,7 @@
           },
           {
             "name": "productId",
+            "description": "Product ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8770,6 +9431,7 @@
           },
           {
             "name": "quantity",
+            "description": "Quantity",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8785,6 +9447,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8800,6 +9463,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8821,10 +9485,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8836,6 +9502,7 @@
           },
           {
             "name": "cartItems",
+            "description": "Cart items",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8855,6 +9522,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8866,6 +9534,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8877,6 +9546,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8888,6 +9558,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8899,6 +9570,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8914,6 +9586,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8935,10 +9608,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddOrUpdateCartAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "address",
+            "description": "Address",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -8954,6 +9629,7 @@
           },
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8965,6 +9641,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8976,6 +9653,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8987,6 +9665,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -8998,6 +9677,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9009,6 +9689,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9024,6 +9705,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9045,10 +9727,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddOrUpdateCartPaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9060,6 +9744,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9071,6 +9756,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9082,6 +9768,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9093,6 +9780,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9104,6 +9792,7 @@
           },
           {
             "name": "payment",
+            "description": "Payment",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9119,6 +9808,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9134,6 +9824,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9155,10 +9846,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddOrUpdateCartShipmentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9170,6 +9863,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9181,6 +9875,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9192,6 +9887,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9203,6 +9899,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9214,6 +9911,7 @@
           },
           {
             "name": "shipment",
+            "description": "Shipment",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9229,6 +9927,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9244,6 +9943,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9265,10 +9965,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddOrUpdateOrderPaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "orderId",
+            "description": "Order ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9284,6 +9986,7 @@
           },
           {
             "name": "payment",
+            "description": "Payment",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9305,10 +10008,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddWishlistBulkItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "listIds",
+            "description": "Wish list ids",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9328,6 +10033,7 @@
           },
           {
             "name": "productId",
+            "description": "Product id to add",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9343,6 +10049,7 @@
           },
           {
             "name": "quantity",
+            "description": "Product quantity to add",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -9360,10 +10067,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddWishlistItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "listId",
+            "description": "Wish list id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9379,6 +10088,7 @@
           },
           {
             "name": "productId",
+            "description": "Product id to add",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9394,6 +10104,7 @@
           },
           {
             "name": "quantity",
+            "description": "Product quantity to add",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -9411,10 +10122,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddWishlistItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "listId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9430,6 +10143,7 @@
           },
           {
             "name": "listItems",
+            "description": "List items",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9459,10 +10173,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -9474,6 +10190,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9485,6 +10202,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9496,6 +10214,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9507,6 +10226,7 @@
           },
           {
             "name": "description",
+            "description": "Description",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9518,6 +10238,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9529,6 +10250,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9540,6 +10262,7 @@
           },
           {
             "name": "id",
+            "description": "ID",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9551,6 +10274,7 @@
           },
           {
             "name": "key",
+            "description": "ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9562,6 +10286,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9573,6 +10298,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9584,6 +10310,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9595,6 +10322,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9606,6 +10334,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9617,6 +10346,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9628,6 +10358,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9639,6 +10370,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9650,6 +10382,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9661,6 +10394,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9672,6 +10406,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9683,6 +10418,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -9700,10 +10436,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputApplicationUserLoginType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "loginProvider",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9719,6 +10457,7 @@
           },
           {
             "name": "providerKey",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9740,10 +10479,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAssignPermissionScopeType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "scope",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9759,6 +10500,7 @@
           },
           {
             "name": "type",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9780,10 +10522,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAssignPermissionType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "assignedScopes",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -9799,6 +10543,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9820,10 +10565,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAssignRoleType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "concurrencyStamp",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9835,6 +10582,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9850,6 +10598,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9865,6 +10614,7 @@
           },
           {
             "name": "permissions",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9890,10 +10640,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputAuthorizePaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "orderId",
+            "description": "Order Id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9905,6 +10657,7 @@
           },
           {
             "name": "parameters",
+            "description": "Input parameters",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -9920,6 +10673,7 @@
           },
           {
             "name": "paymentId",
+            "description": "Payment Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -9941,10 +10695,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeAllCartItemsSelectedType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9956,6 +10712,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9967,6 +10724,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9978,6 +10736,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -9989,6 +10748,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10000,6 +10760,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10015,6 +10776,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10036,10 +10798,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeCartItemCommentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10051,6 +10815,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10062,6 +10827,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10073,6 +10839,7 @@
           },
           {
             "name": "comment",
+            "description": "Comment",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10088,6 +10855,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10099,6 +10867,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10110,6 +10879,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10125,6 +10895,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10140,6 +10911,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10161,10 +10933,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeCartItemPriceType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10176,6 +10950,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10187,6 +10962,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10198,6 +10974,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10209,6 +10986,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10220,6 +10998,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10235,6 +11014,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10250,6 +11030,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10265,6 +11046,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10286,10 +11068,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeCartItemQuantityType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10301,6 +11085,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10312,6 +11097,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10323,6 +11109,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10334,6 +11121,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10345,6 +11133,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10360,6 +11149,7 @@
           },
           {
             "name": "quantity",
+            "description": "Quantity",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10375,6 +11165,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10390,6 +11181,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10411,10 +11203,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeCartItemSelectedType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10426,6 +11220,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10437,6 +11232,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10448,6 +11244,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10459,6 +11256,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10470,6 +11268,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10485,6 +11284,7 @@
           },
           {
             "name": "selectedForCheckout",
+            "description": "Is item selected for checkout",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10500,6 +11300,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10515,6 +11316,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10536,10 +11338,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeCartItemsSelectedType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10551,6 +11355,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10562,6 +11367,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10573,6 +11379,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10584,6 +11391,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10595,6 +11403,7 @@
           },
           {
             "name": "lineItemIds",
+            "description": "List of line item Ids",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -10610,6 +11419,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10625,6 +11435,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10646,10 +11457,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeCommentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10661,6 +11474,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10672,6 +11486,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10683,6 +11498,7 @@
           },
           {
             "name": "comment",
+            "description": "Comment",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10694,6 +11510,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10705,6 +11522,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10716,6 +11534,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10731,6 +11550,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10752,10 +11572,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeOrderStatusType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "orderId",
+            "description": "Order ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10771,6 +11593,7 @@
           },
           {
             "name": "status",
+            "description": "Order status",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10792,10 +11615,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeOrganizationContactRoleType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "roleIds",
+            "description": "Role IDs or names to be assigned to the user",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -10815,6 +11640,7 @@
           },
           {
             "name": "userId",
+            "description": "User identifier to be changed",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10832,10 +11658,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangePasswordType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "newPassword",
+            "description": "New password according with system security policy",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10851,6 +11679,7 @@
           },
           {
             "name": "oldPassword",
+            "description": "Old user password",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10866,6 +11695,7 @@
           },
           {
             "name": "userId",
+            "description": "User identifier",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10887,10 +11717,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangePurchaseOrderNumber",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10902,6 +11734,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10913,6 +11746,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10924,6 +11758,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10935,6 +11770,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10946,6 +11782,7 @@
           },
           {
             "name": "purchaseOrderNumber",
+            "description": "Purchase Order Number",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -10957,6 +11794,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10972,6 +11810,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -10993,10 +11832,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputChangeWishlistType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cultureName",
+            "description": "Culture name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11008,6 +11849,7 @@
           },
           {
             "name": "description",
+            "description": "List description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11019,6 +11861,7 @@
           },
           {
             "name": "listId",
+            "description": "List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11034,6 +11877,7 @@
           },
           {
             "name": "listName",
+            "description": "New List name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11045,6 +11889,7 @@
           },
           {
             "name": "scope",
+            "description": "List scope (private or organization)",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11062,10 +11907,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputClearCartType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11077,6 +11924,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11088,6 +11936,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11099,6 +11948,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11110,6 +11960,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11121,6 +11972,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11136,6 +11988,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11157,10 +12010,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputClearPaymentsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11172,6 +12027,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11183,6 +12039,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11194,6 +12051,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11205,6 +12063,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11216,6 +12075,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11231,6 +12091,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11252,10 +12113,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputClearShipmentsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11267,6 +12130,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11278,6 +12142,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11289,6 +12154,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11300,6 +12166,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11311,6 +12178,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11326,6 +12194,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11347,10 +12216,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCloneWishlistType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cultureName",
+            "description": "Culture name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11362,6 +12233,7 @@
           },
           {
             "name": "currencyCode",
+            "description": "Currency code",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11373,6 +12245,7 @@
           },
           {
             "name": "description",
+            "description": "List description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11384,6 +12257,7 @@
           },
           {
             "name": "listId",
+            "description": "Source List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11399,6 +12273,7 @@
           },
           {
             "name": "listName",
+            "description": "List name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11410,6 +12285,7 @@
           },
           {
             "name": "scope",
+            "description": "List scope (private or organization)",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11421,6 +12297,7 @@
           },
           {
             "name": "storeId",
+            "description": "Store ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11436,6 +12313,7 @@
           },
           {
             "name": "userId",
+            "description": "Owner ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11457,10 +12335,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputConfirmEmailType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "token",
+            "description": "Confirm email token",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11476,6 +12356,7 @@
           },
           {
             "name": "userId",
+            "description": "User identifier",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11497,10 +12378,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCreateApplicationUserType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "createdBy",
+            "description": "Username of the creator",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11512,6 +12395,7 @@
           },
           {
             "name": "createdDate",
+            "description": "Date of user creation",
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
@@ -11523,6 +12407,7 @@
           },
           {
             "name": "email",
+            "description": "User Email",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11538,6 +12423,7 @@
           },
           {
             "name": "id",
+            "description": "User ID",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11549,6 +12435,7 @@
           },
           {
             "name": "lockoutEnabled",
+            "description": "Can user be locked out",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11560,6 +12447,7 @@
           },
           {
             "name": "lockoutEnd",
+            "description": "End date of lockout",
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
@@ -11571,6 +12459,7 @@
           },
           {
             "name": "logins",
+            "description": "External logins",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11586,6 +12475,7 @@
           },
           {
             "name": "memberId",
+            "description": "Id of the associated Member",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11597,6 +12487,7 @@
           },
           {
             "name": "password",
+            "description": "User password (nullable, for external logins)",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11608,6 +12499,7 @@
           },
           {
             "name": "passwordExpired",
+            "description": "Password expiration date",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11619,6 +12511,7 @@
           },
           {
             "name": "phoneNumber",
+            "description": "User phone number",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11630,6 +12523,7 @@
           },
           {
             "name": "phoneNumberConfirmed",
+            "description": "Is user phone number confirmed",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11641,6 +12535,7 @@
           },
           {
             "name": "photoUrl",
+            "description": "User photo URL",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11652,6 +12547,7 @@
           },
           {
             "name": "roles",
+            "description": "List of user roles",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11667,6 +12563,7 @@
           },
           {
             "name": "storeId",
+            "description": "Associated Store Id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11678,6 +12575,7 @@
           },
           {
             "name": "twoFactorEnabled",
+            "description": "Is Two Factor Authentication enabled",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -11689,6 +12587,7 @@
           },
           {
             "name": "userName",
+            "description": "User name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11704,6 +12603,7 @@
           },
           {
             "name": "userType",
+            "description": "User type (Manager, Customer)",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11725,10 +12625,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCreateContactType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "about",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11740,6 +12642,7 @@
           },
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11755,6 +12658,7 @@
           },
           {
             "name": "defaultLanguage",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11766,6 +12670,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11781,6 +12686,7 @@
           },
           {
             "name": "emails",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11796,6 +12702,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11811,6 +12718,7 @@
           },
           {
             "name": "fullName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11822,6 +12730,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11837,6 +12746,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11848,6 +12758,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -11863,6 +12774,7 @@
           },
           {
             "name": "memberType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11874,6 +12786,7 @@
           },
           {
             "name": "middleName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11885,6 +12798,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11896,6 +12810,7 @@
           },
           {
             "name": "organizations",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11911,6 +12826,7 @@
           },
           {
             "name": "phones",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -11926,6 +12842,7 @@
           },
           {
             "name": "photoUrl",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11937,6 +12854,7 @@
           },
           {
             "name": "salutation",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11948,6 +12866,7 @@
           },
           {
             "name": "timeZone",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11965,10 +12884,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCreateOrderFromCartType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": "Cart ID",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -11986,10 +12907,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCreateOrganizationType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -12005,6 +12928,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -12020,6 +12944,7 @@
           },
           {
             "name": "emails",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -12035,6 +12960,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -12050,6 +12976,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12061,6 +12988,7 @@
           },
           {
             "name": "memberType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12072,6 +13000,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12083,6 +13012,7 @@
           },
           {
             "name": "phones",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -12104,10 +13034,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCreateUserType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "applicationUser",
+            "description": "Application user to create",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12129,10 +13061,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputCreateWishlistType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cultureName",
+            "description": "Culture name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12144,6 +13078,7 @@
           },
           {
             "name": "currencyCode",
+            "description": "Currency code",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12155,6 +13090,7 @@
           },
           {
             "name": "description",
+            "description": "List description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12166,6 +13102,7 @@
           },
           {
             "name": "listName",
+            "description": "List name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12177,6 +13114,7 @@
           },
           {
             "name": "scope",
+            "description": "List scope (private or organization)",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12188,6 +13126,7 @@
           },
           {
             "name": "storeId",
+            "description": "Store ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12203,6 +13142,7 @@
           },
           {
             "name": "userId",
+            "description": "Owner ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12224,10 +13164,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputDeleteContactType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "contactId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12249,10 +13191,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputDeleteMemberAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12272,6 +13216,7 @@
           },
           {
             "name": "memberId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12293,10 +13238,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputDeleteUserType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "userNames",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12322,10 +13269,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputDynamicPropertyValueType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cultureName",
+            "description": "Culture name (\"en-US\") for multilingual property",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12337,6 +13286,7 @@
           },
           {
             "name": "locale",
+            "description": "Language (\"en-US\") for multilingual property",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12348,6 +13298,7 @@
           },
           {
             "name": "name",
+            "description": "Dynamic property name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12363,6 +13314,7 @@
           },
           {
             "name": "value",
+            "description": "Dynamic property value. ID must be passed for dictionary item",
             "type": {
               "kind": "SCALAR",
               "name": "DynamicPropertyValue",
@@ -12380,10 +13332,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputInitializePaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "orderId",
+            "description": "Order Id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12395,6 +13349,7 @@
           },
           {
             "name": "paymentId",
+            "description": "Payment Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12416,10 +13371,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputInviteUserType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "customerOrderId",
+            "description": "Customer order Id to be associated with this user.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12431,6 +13388,7 @@
           },
           {
             "name": "emails",
+            "description": "Emails which will receive invites",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12454,6 +13412,7 @@
           },
           {
             "name": "message",
+            "description": "Optional message to include into email with instructions which invites persons will see",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12465,6 +13424,7 @@
           },
           {
             "name": "organizationId",
+            "description": "ID of organization where contact will be added for user",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12476,6 +13436,7 @@
           },
           {
             "name": "roleIds",
+            "description": "Role IDs or names to be assigned to the invited user",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -12495,6 +13456,7 @@
           },
           {
             "name": "storeId",
+            "description": "ID of store which will send invites",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12510,6 +13472,7 @@
           },
           {
             "name": "urlSuffix",
+            "description": "Optional URL suffix: you may provide here relative URL to your page which handle registration by invite",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12527,10 +13490,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputKeyValueType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "key",
+            "description": "Dictionary key",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12546,6 +13511,7 @@
           },
           {
             "name": "value",
+            "description": "Dictionary value",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12563,10 +13529,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputLockUnlockOrganizationContactType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12584,10 +13552,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputMemberAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -12599,6 +13569,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12614,6 +13585,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12629,6 +13601,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12640,6 +13613,7 @@
           },
           {
             "name": "description",
+            "description": "Description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12651,6 +13625,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12662,6 +13637,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12673,6 +13649,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12684,6 +13661,7 @@
           },
           {
             "name": "key",
+            "description": "key",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12695,6 +13673,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12706,6 +13685,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12721,6 +13701,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12732,6 +13713,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12743,6 +13725,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12754,6 +13737,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12765,6 +13749,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12776,6 +13761,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12787,6 +13773,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12802,6 +13789,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12813,6 +13801,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12824,6 +13813,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12841,10 +13831,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputMergeCartType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12856,6 +13848,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12867,6 +13860,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12878,6 +13872,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12889,6 +13884,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -12900,6 +13896,7 @@
           },
           {
             "name": "secondCartId",
+            "description": "Second cart Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12915,6 +13912,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12930,6 +13928,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12951,10 +13950,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputMoveWishlistItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "destinationListId",
+            "description": "Destination List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12970,6 +13971,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item ID to move",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12985,6 +13987,7 @@
           },
           {
             "name": "listId",
+            "description": "Source List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13006,10 +14009,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputNewBulkItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "productSku",
+            "description": "Product SKU",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13025,6 +14030,7 @@
           },
           {
             "name": "quantity",
+            "description": "Product quantity",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -13042,10 +14048,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputNewCartItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -13061,6 +14069,7 @@
           },
           {
             "name": "productId",
+            "description": "Product Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13076,6 +14085,7 @@
           },
           {
             "name": "quantity",
+            "description": "Product quantity",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -13093,10 +14103,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputNewWishlistItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "productId",
+            "description": "Product Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13112,6 +14124,7 @@
           },
           {
             "name": "quantity",
+            "description": "Product quantity",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -13129,10 +14142,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputOrderAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -13144,6 +14159,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13155,6 +14171,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13166,6 +14183,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13177,6 +14195,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13188,6 +14207,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13199,6 +14219,7 @@
           },
           {
             "name": "id",
+            "description": "ID",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13210,6 +14231,7 @@
           },
           {
             "name": "key",
+            "description": "Id",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13221,6 +14243,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13232,6 +14255,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13243,6 +14267,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13254,6 +14279,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13265,6 +14291,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13276,6 +14303,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13287,6 +14315,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer id",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13298,6 +14327,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13309,6 +14339,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13320,6 +14351,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region id",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13331,6 +14363,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region name",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13342,6 +14375,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13359,10 +14393,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputOrderBankCardInfoType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "bankCardCVV2",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13378,6 +14414,7 @@
           },
           {
             "name": "bankCardMonth",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13393,6 +14430,7 @@
           },
           {
             "name": "bankCardNumber",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13408,6 +14446,7 @@
           },
           {
             "name": "bankCardType",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13423,6 +14462,7 @@
           },
           {
             "name": "bankCardYear",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13438,6 +14478,7 @@
           },
           {
             "name": "cardholderName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13459,10 +14500,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputOrderPaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "amount",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalDecimal",
@@ -13474,6 +14517,7 @@
           },
           {
             "name": "billingAddress",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputOrderAddressType",
@@ -13485,6 +14529,7 @@
           },
           {
             "name": "comment",
+            "description": "Text comment",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13496,6 +14541,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13507,6 +14553,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -13522,6 +14569,7 @@
           },
           {
             "name": "id",
+            "description": "Payment ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13533,6 +14581,7 @@
           },
           {
             "name": "outerId",
+            "description": "Payment outer ID value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13544,6 +14593,7 @@
           },
           {
             "name": "paymentGatewayCode",
+            "description": "Payment gateway code value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13555,6 +14605,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalDecimal",
@@ -13566,6 +14617,7 @@
           },
           {
             "name": "vendorId",
+            "description": "Payment vendor ID value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13583,10 +14635,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputPaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "amount",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalDecimal",
@@ -13598,6 +14652,7 @@
           },
           {
             "name": "billingAddress",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputAddressType",
@@ -13609,6 +14664,7 @@
           },
           {
             "name": "comment",
+            "description": "Text comment",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13620,6 +14676,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13631,6 +14688,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -13646,6 +14704,7 @@
           },
           {
             "name": "id",
+            "description": "Payment ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13657,6 +14716,7 @@
           },
           {
             "name": "outerId",
+            "description": "Payment outer ID value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13668,6 +14728,7 @@
           },
           {
             "name": "paymentGatewayCode",
+            "description": "Payment gateway code value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13679,6 +14740,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalDecimal",
@@ -13690,6 +14752,7 @@
           },
           {
             "name": "purpose",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13701,6 +14764,7 @@
           },
           {
             "name": "vendorId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -13718,10 +14782,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputPersonalDataType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "email",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13733,6 +14799,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13744,6 +14811,7 @@
           },
           {
             "name": "fullName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13755,6 +14823,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13766,6 +14835,7 @@
           },
           {
             "name": "middleName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13783,10 +14853,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputProcessOrderPaymentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "bankCardInfo",
+            "description": "Credit card details",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputOrderBankCardInfoType",
@@ -13798,6 +14870,7 @@
           },
           {
             "name": "orderId",
+            "description": "Order ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13813,6 +14886,7 @@
           },
           {
             "name": "paymentId",
+            "description": "Payment ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13834,10 +14908,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputQuoteAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -13849,6 +14925,7 @@
           },
           {
             "name": "city",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13864,6 +14941,7 @@
           },
           {
             "name": "countryCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13875,6 +14953,7 @@
           },
           {
             "name": "countryName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13890,6 +14969,7 @@
           },
           {
             "name": "email",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13901,6 +14981,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13916,6 +14997,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13927,6 +15009,7 @@
           },
           {
             "name": "key",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13938,6 +15021,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -13953,6 +15037,7 @@
           },
           {
             "name": "line1",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13964,6 +15049,7 @@
           },
           {
             "name": "line2",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13975,6 +15061,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13986,6 +15073,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13997,6 +15085,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14008,6 +15097,7 @@
           },
           {
             "name": "phone",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14019,6 +15109,7 @@
           },
           {
             "name": "postalCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14030,6 +15121,7 @@
           },
           {
             "name": "regionId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14041,6 +15133,7 @@
           },
           {
             "name": "regionName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14058,10 +15151,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRegisterAccountType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "email",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14077,6 +15172,7 @@
           },
           {
             "name": "password",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14092,6 +15188,7 @@
           },
           {
             "name": "username",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14113,10 +15210,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRegisterByInvitationType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "customerOrderId",
+            "description": "Customer order Id to be associated with this user.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14128,6 +15227,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name of person",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14143,6 +15243,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name of person",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14158,6 +15259,7 @@
           },
           {
             "name": "password",
+            "description": "Password",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14173,6 +15275,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14184,6 +15287,7 @@
           },
           {
             "name": "token",
+            "description": "Invitation token",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14199,6 +15303,7 @@
           },
           {
             "name": "userId",
+            "description": "ID of use created for invited email",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14214,6 +15319,7 @@
           },
           {
             "name": "username",
+            "description": "Username",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14235,10 +15341,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRegisterContactType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "about",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14250,6 +15358,7 @@
           },
           {
             "name": "address",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputMemberAddressType",
@@ -14261,6 +15370,7 @@
           },
           {
             "name": "birthdate",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Date",
@@ -14272,6 +15382,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -14287,6 +15398,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14302,6 +15414,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14317,6 +15430,7 @@
           },
           {
             "name": "middleName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14328,6 +15442,7 @@
           },
           {
             "name": "phoneNumber",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14345,10 +15460,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRegisterOrganizationType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "address",
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputMemberAddressType",
@@ -14360,6 +15477,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14371,6 +15489,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -14386,6 +15505,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14407,10 +15527,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRejectGiftItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14422,6 +15544,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14433,6 +15556,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14444,6 +15568,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14455,6 +15580,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14466,6 +15592,7 @@
           },
           {
             "name": "ids",
+            "description": "Ids of gift lineItems to reject from cart",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14485,6 +15612,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14500,6 +15628,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14521,10 +15650,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveCartAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressId",
+            "description": "Address Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14540,6 +15671,7 @@
           },
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14551,6 +15683,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14562,6 +15695,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14573,6 +15707,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14584,6 +15719,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14595,6 +15731,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14610,6 +15747,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14631,10 +15769,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveCartType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": "Cart Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14650,6 +15790,7 @@
           },
           {
             "name": "userId",
+            "description": "User Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14671,10 +15812,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveCouponType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14686,6 +15829,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14697,6 +15841,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14708,6 +15853,7 @@
           },
           {
             "name": "couponCode",
+            "description": "Coupon code",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14719,6 +15865,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14730,6 +15877,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14741,6 +15889,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14756,6 +15905,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14777,10 +15927,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14792,6 +15944,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14803,6 +15956,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14814,6 +15968,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14825,6 +15980,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14836,6 +15992,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14851,6 +16008,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14866,6 +16024,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14887,10 +16046,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14902,6 +16063,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14913,6 +16075,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14924,6 +16087,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14935,6 +16099,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -14946,6 +16111,7 @@
           },
           {
             "name": "lineItemIds",
+            "description": "Array of line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14965,6 +16131,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -14980,6 +16147,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15001,10 +16169,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveMemberFromOrganizationType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "contactId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15016,6 +16186,7 @@
           },
           {
             "name": "organizationId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15033,10 +16204,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveShipmentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15048,6 +16221,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15059,6 +16233,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15070,6 +16245,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15081,6 +16257,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15092,6 +16269,7 @@
           },
           {
             "name": "shipmentId",
+            "description": "Shipment Id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15103,6 +16281,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15118,6 +16297,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15139,10 +16319,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveWishlistItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "lineItemId",
+            "description": "Line item ID to remove",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15158,6 +16340,7 @@
           },
           {
             "name": "listId",
+            "description": "List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15179,10 +16362,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveWishlistItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "lineItemIds",
+            "description": "Line item IDs to remove",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15206,6 +16391,7 @@
           },
           {
             "name": "listId",
+            "description": "List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15227,10 +16413,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRemoveWishlistType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "listId",
+            "description": "List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15252,10 +16440,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRenameWishlistType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "listId",
+            "description": "List ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15271,6 +16461,7 @@
           },
           {
             "name": "listName",
+            "description": "New List name",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15288,10 +16479,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputRequestRegistrationType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "account",
+            "description": "Creating contact's account",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15307,6 +16500,7 @@
           },
           {
             "name": "contact",
+            "description": "Creating contact",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15322,6 +16516,7 @@
           },
           {
             "name": "languageCode",
+            "description": "Notification language code",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15333,6 +16528,7 @@
           },
           {
             "name": "organization",
+            "description": "company type",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputRegisterOrganizationType",
@@ -15344,6 +16540,7 @@
           },
           {
             "name": "storeId",
+            "description": "Store ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15365,10 +16562,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputResetPasswordByTokenType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "newPassword",
+            "description": "New password according with system security policy",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15384,6 +16583,7 @@
           },
           {
             "name": "token",
+            "description": "User password reset token",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15399,6 +16599,7 @@
           },
           {
             "name": "userId",
+            "description": "User identifier",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15420,10 +16621,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputSendVerifyEmailType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "email",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15435,6 +16638,7 @@
           },
           {
             "name": "languageCode",
+            "description": "Notification language code",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15446,6 +16650,7 @@
           },
           {
             "name": "storeId",
+            "description": "Store ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15461,6 +16666,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15478,10 +16684,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputShipmentType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "comment",
+            "description": "Text comment",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15493,6 +16701,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15504,6 +16713,7 @@
           },
           {
             "name": "deliveryAddress",
+            "description": "Delivery address",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "InputAddressType",
@@ -15515,6 +16725,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -15530,6 +16741,7 @@
           },
           {
             "name": "fulfillmentCenterId",
+            "description": "Fulfillment center iD",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15541,6 +16753,7 @@
           },
           {
             "name": "height",
+            "description": "Height value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalNullableDecimal",
@@ -15552,6 +16765,7 @@
           },
           {
             "name": "id",
+            "description": "Shipment ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15563,6 +16777,7 @@
           },
           {
             "name": "length",
+            "description": "Length value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalNullableDecimal",
@@ -15574,6 +16789,7 @@
           },
           {
             "name": "measureUnit",
+            "description": "Measurement unit value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15585,6 +16801,7 @@
           },
           {
             "name": "price",
+            "description": "Price value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalDecimal",
@@ -15596,6 +16813,7 @@
           },
           {
             "name": "shipmentMethodCode",
+            "description": "Shipping method code",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15607,6 +16825,7 @@
           },
           {
             "name": "shipmentMethodOption",
+            "description": "Shipping method option",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15618,6 +16837,7 @@
           },
           {
             "name": "vendorId",
+            "description": "Vendor ID",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15629,6 +16849,7 @@
           },
           {
             "name": "volumetricWeight",
+            "description": "Volumetric weight value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalNullableDecimal",
@@ -15640,6 +16861,7 @@
           },
           {
             "name": "weight",
+            "description": "Weight value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalNullableDecimal",
@@ -15651,6 +16873,7 @@
           },
           {
             "name": "weightUnit",
+            "description": "Weight unit value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalString",
@@ -15662,6 +16885,7 @@
           },
           {
             "name": "width",
+            "description": "Width value",
             "type": {
               "kind": "SCALAR",
               "name": "OptionalNullableDecimal",
@@ -15679,10 +16903,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateApplicationUserType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "accessFailedCount",
+            "description": "Failed login attempts for the current user",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -15694,6 +16920,7 @@
           },
           {
             "name": "email",
+            "description": "User Email",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15709,6 +16936,7 @@
           },
           {
             "name": "id",
+            "description": "User ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15724,6 +16952,7 @@
           },
           {
             "name": "lockoutEnabled",
+            "description": "Can user be locked out",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -15735,6 +16964,7 @@
           },
           {
             "name": "lockoutEnd",
+            "description": "End date of lockout",
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
@@ -15746,6 +16976,7 @@
           },
           {
             "name": "memberId",
+            "description": "Id of the associated Memeber",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15757,6 +16988,7 @@
           },
           {
             "name": "passwordHash",
+            "description": "Password Hash",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15768,6 +17000,7 @@
           },
           {
             "name": "phoneNumber",
+            "description": "User phone number",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15779,6 +17012,7 @@
           },
           {
             "name": "phoneNumberConfirmed",
+            "description": "Is user phone number confirmed",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -15790,6 +17024,7 @@
           },
           {
             "name": "photoUrl",
+            "description": "User photo URL",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15801,6 +17036,7 @@
           },
           {
             "name": "roles",
+            "description": "List of user roles",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -15816,6 +17052,7 @@
           },
           {
             "name": "securityStamp",
+            "description": "SecurityStamp",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15831,6 +17068,7 @@
           },
           {
             "name": "storeId",
+            "description": "Associated Store Id",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15842,6 +17080,7 @@
           },
           {
             "name": "twoFactorEnabled",
+            "description": "Is Two Factor Authentication enabled",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -15853,6 +17092,7 @@
           },
           {
             "name": "userName",
+            "description": "User name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15868,6 +17108,7 @@
           },
           {
             "name": "userType",
+            "description": "User type (Manager, Customer)",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15889,10 +17130,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateCartDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15904,6 +17147,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15915,6 +17159,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15926,6 +17171,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15937,6 +17183,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -15948,6 +17195,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15967,6 +17215,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15982,6 +17231,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16003,10 +17253,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateCartItemDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16018,6 +17270,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16029,6 +17282,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16040,6 +17294,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16051,6 +17306,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16062,6 +17318,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16081,6 +17338,7 @@
           },
           {
             "name": "lineItemId",
+            "description": "Line item Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16096,6 +17354,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16111,6 +17370,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16132,10 +17392,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateCartPaymentDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16147,6 +17409,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16158,6 +17421,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16169,6 +17433,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16180,6 +17445,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16191,6 +17457,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16210,6 +17477,7 @@
           },
           {
             "name": "paymentId",
+            "description": "Payment Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16225,6 +17493,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16240,6 +17509,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16261,10 +17531,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateCartShipmentDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16276,6 +17548,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16287,6 +17560,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16298,6 +17572,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16309,6 +17584,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16320,6 +17596,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic properties",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16339,6 +17616,7 @@
           },
           {
             "name": "shipmentId",
+            "description": "Shipment Id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16354,6 +17632,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16369,6 +17648,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16390,10 +17670,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateContactType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "about",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16405,6 +17687,7 @@
           },
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16420,6 +17703,7 @@
           },
           {
             "name": "defaultLanguage",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16431,6 +17715,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16446,6 +17731,7 @@
           },
           {
             "name": "emails",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16461,6 +17747,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16476,6 +17763,7 @@
           },
           {
             "name": "fullName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16487,6 +17775,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16502,6 +17791,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16517,6 +17807,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16532,6 +17823,7 @@
           },
           {
             "name": "memberType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16543,6 +17835,7 @@
           },
           {
             "name": "middleName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16554,6 +17847,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16565,6 +17859,7 @@
           },
           {
             "name": "organizations",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16580,6 +17875,7 @@
           },
           {
             "name": "phones",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16595,6 +17891,7 @@
           },
           {
             "name": "photoUrl",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16606,6 +17903,7 @@
           },
           {
             "name": "salutation",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16617,6 +17915,7 @@
           },
           {
             "name": "timeZone",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16634,10 +17933,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateMemberAddressType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16657,6 +17958,7 @@
           },
           {
             "name": "memberId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16678,10 +17980,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateMemberDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16701,6 +18005,7 @@
           },
           {
             "name": "memberId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16722,10 +18027,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateOrderDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16745,6 +18052,7 @@
           },
           {
             "name": "orderId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16762,10 +18070,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateOrderItemDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16785,6 +18095,7 @@
           },
           {
             "name": "lineItemId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16796,6 +18107,7 @@
           },
           {
             "name": "orderId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16813,10 +18125,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateOrderPaymentDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16836,6 +18150,7 @@
           },
           {
             "name": "orderId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16847,6 +18162,7 @@
           },
           {
             "name": "paymentId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16864,10 +18180,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateOrderShipmentDynamicPropertiesType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16887,6 +18205,7 @@
           },
           {
             "name": "orderId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16898,6 +18217,7 @@
           },
           {
             "name": "shipmentId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -16915,10 +18235,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateOrganizationType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16934,6 +18256,7 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16949,6 +18272,7 @@
           },
           {
             "name": "emails",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16964,6 +18288,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -16979,6 +18304,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -16994,6 +18320,7 @@
           },
           {
             "name": "memberType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17005,6 +18332,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17016,6 +18344,7 @@
           },
           {
             "name": "phones",
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -17037,10 +18366,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdatePersonalDataType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "personalData",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17062,10 +18393,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateRoleInnerType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "concurrencyStamp",
+            "description": "Concurrency Stamp",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17077,6 +18410,7 @@
           },
           {
             "name": "description",
+            "description": "Role description",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17088,6 +18422,7 @@
           },
           {
             "name": "id",
+            "description": "Role ID",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17103,6 +18438,7 @@
           },
           {
             "name": "name",
+            "description": "Role name",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17118,6 +18454,7 @@
           },
           {
             "name": "permissions",
+            "description": "List of Role permissions",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17143,10 +18480,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateRoleType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "role",
+            "description": "Role to update",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17168,10 +18507,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateUserType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "applicationUser",
+            "description": "Application user to update",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17193,10 +18534,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateWishlistItemsType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "items",
+            "description": "Bulk wishlist items",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17216,6 +18559,7 @@
           },
           {
             "name": "listId",
+            "description": "Wish list id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17237,10 +18581,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputUpdateWishlistLineItemType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "lineItemId",
+            "description": "Line Item Id to update",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17256,6 +18602,7 @@
           },
           {
             "name": "quantity",
+            "description": "Product quantity to add",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17277,10 +18624,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "InputValidateCouponType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17292,6 +18641,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17303,6 +18653,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17314,6 +18665,7 @@
           },
           {
             "name": "coupon",
+            "description": "Coupon",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17329,6 +18681,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17340,6 +18693,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -17351,6 +18705,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17366,6 +18721,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -17387,6 +18743,7 @@
       {
         "kind": "SCALAR",
         "name": "Int",
+        "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -17396,9 +18753,11 @@
       {
         "kind": "OBJECT",
         "name": "InventoryInfo",
+        "description": "",
         "fields": [
           {
             "name": "allowBackorder",
+            "description": "Allow backorder",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17414,6 +18773,7 @@
           },
           {
             "name": "allowPreorder",
+            "description": "Allow preorder",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17429,6 +18789,7 @@
           },
           {
             "name": "backorderAvailabilityDate",
+            "description": "Backorder availability date",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17440,6 +18801,7 @@
           },
           {
             "name": "fulfillmentCenterId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17455,6 +18817,7 @@
           },
           {
             "name": "fulfillmentCenterName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17470,6 +18833,7 @@
           },
           {
             "name": "inStockQuantity",
+            "description": "Inventory in stock quantity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17485,6 +18849,7 @@
           },
           {
             "name": "preorderAvailabilityDate",
+            "description": "Preorder availability date",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17496,6 +18861,7 @@
           },
           {
             "name": "reservedQuantity",
+            "description": "Inventory reserved quantity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17518,9 +18884,11 @@
       {
         "kind": "OBJECT",
         "name": "KeyValueType",
+        "description": null,
         "fields": [
           {
             "name": "key",
+            "description": "Dictionary key",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17536,6 +18904,7 @@
           },
           {
             "name": "value",
+            "description": "Dictionary value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17554,9 +18923,11 @@
       {
         "kind": "OBJECT",
         "name": "LanguageType",
+        "description": null,
         "fields": [
           {
             "name": "cultureName",
+            "description": "Culture name format (e.g. en-US)",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17572,6 +18943,7 @@
           },
           {
             "name": "isInvariant",
+            "description": "Is invariant",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17587,6 +18959,7 @@
           },
           {
             "name": "nativeName",
+            "description": "Native name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17602,6 +18975,7 @@
           },
           {
             "name": "threeLetterLanguageName",
+            "description": "ISO 639-2 three-letter code for the language.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17617,6 +18991,7 @@
           },
           {
             "name": "threeLetterRegionName",
+            "description": "Three-letter code defined in ISO 3166 for the country/region.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17632,6 +19007,7 @@
           },
           {
             "name": "twoLetterLanguageName",
+            "description": "ISO 639-1 two-letter code for the language.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17647,6 +19023,7 @@
           },
           {
             "name": "twoLetterRegionName",
+            "description": "Two-letter code defined in ISO 3166 for the country/region.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17669,9 +19046,11 @@
       {
         "kind": "OBJECT",
         "name": "LineItemType",
+        "description": null,
         "fields": [
           {
             "name": "catalogId",
+            "description": "Catalog ID value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17687,6 +19066,7 @@
           },
           {
             "name": "categoryId",
+            "description": "Category ID value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17698,6 +19078,7 @@
           },
           {
             "name": "createdDate",
+            "description": "Line item create date",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17713,6 +19094,7 @@
           },
           {
             "name": "discountAmount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17728,6 +19110,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17743,6 +19126,7 @@
           },
           {
             "name": "discountTotal",
+            "description": "Total discount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17758,6 +19142,7 @@
           },
           {
             "name": "discountTotalWithTax",
+            "description": "Total discount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17773,6 +19158,7 @@
           },
           {
             "name": "discounts",
+            "description": "Discounts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17796,9 +19182,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Cart line item dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -17823,6 +19211,7 @@
           },
           {
             "name": "extendedPrice",
+            "description": "Extended price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17838,6 +19227,7 @@
           },
           {
             "name": "extendedPriceWithTax",
+            "description": "Extended price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17853,6 +19243,7 @@
           },
           {
             "name": "fulfillmentCenterId",
+            "description": "Line item fulfillment center ID value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17864,6 +19255,7 @@
           },
           {
             "name": "fulfillmentCenterName",
+            "description": "Line item fulfillment center name value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17875,6 +19267,7 @@
           },
           {
             "name": "height",
+            "description": "Height value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17886,6 +19279,7 @@
           },
           {
             "name": "id",
+            "description": "Line item ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17901,6 +19295,7 @@
           },
           {
             "name": "imageUrl",
+            "description": "Value of line item image absolute URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17912,6 +19307,7 @@
           },
           {
             "name": "inStockQuantity",
+            "description": "In stock quantity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17927,6 +19323,7 @@
           },
           {
             "name": "isGift",
+            "description": "flag of line item is a gift",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17942,6 +19339,7 @@
           },
           {
             "name": "isReadOnly",
+            "description": "Shows whether this is read-only",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17957,6 +19355,7 @@
           },
           {
             "name": "isReccuring",
+            "description": "Shows whether the line item is recurring",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17972,6 +19371,7 @@
           },
           {
             "name": "isValid",
+            "description": "Shows whether this is valid",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -17987,6 +19387,7 @@
           },
           {
             "name": "languageCode",
+            "description": "Culture name in the ISO 3166-1 alpha-3 format",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -17998,6 +19399,7 @@
           },
           {
             "name": "length",
+            "description": "Length value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18009,6 +19411,7 @@
           },
           {
             "name": "listPrice",
+            "description": "List price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18024,6 +19427,7 @@
           },
           {
             "name": "listPriceWithTax",
+            "description": "List price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18039,6 +19443,7 @@
           },
           {
             "name": "measureUnit",
+            "description": "Measurement unit value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18050,6 +19455,7 @@
           },
           {
             "name": "name",
+            "description": "Line item name value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18065,6 +19471,7 @@
           },
           {
             "name": "note",
+            "description": "Line item comment",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18076,6 +19483,7 @@
           },
           {
             "name": "objectType",
+            "description": "Line item quantity value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18091,6 +19499,7 @@
           },
           {
             "name": "placedPrice",
+            "description": "Placed price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18106,6 +19515,7 @@
           },
           {
             "name": "placedPriceWithTax",
+            "description": "Placed price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18121,6 +19531,7 @@
           },
           {
             "name": "product",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -18132,6 +19543,7 @@
           },
           {
             "name": "productId",
+            "description": "Product ID value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18147,6 +19559,7 @@
           },
           {
             "name": "productOuterId",
+            "description": "Product outer Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18158,6 +19571,7 @@
           },
           {
             "name": "productType",
+            "description": "Product type: Physical, Digital, or Subscription",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18169,6 +19583,7 @@
           },
           {
             "name": "quantity",
+            "description": "Line item quantity value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18184,6 +19599,7 @@
           },
           {
             "name": "requiredShipping",
+            "description": "Requirement for line item shipping",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18199,6 +19615,7 @@
           },
           {
             "name": "salePrice",
+            "description": "Sale price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18214,6 +19631,7 @@
           },
           {
             "name": "salePriceWithTax",
+            "description": "Sale price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18229,6 +19647,7 @@
           },
           {
             "name": "selectedForCheckout",
+            "description": "Shows whether the line item is selected for buying",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18244,6 +19663,7 @@
           },
           {
             "name": "shipmentMethodCode",
+            "description": "Line item shipping method code value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18255,6 +19675,7 @@
           },
           {
             "name": "sku",
+            "description": "Product SKU value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18270,6 +19691,7 @@
           },
           {
             "name": "taxDetails",
+            "description": "Tax details",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18293,6 +19715,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": "Total shipping tax amount value",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18308,6 +19731,7 @@
           },
           {
             "name": "taxTotal",
+            "description": "Tax total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18323,6 +19747,7 @@
           },
           {
             "name": "taxType",
+            "description": "Shipping tax type value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18334,6 +19759,7 @@
           },
           {
             "name": "thumbnailImageUrl",
+            "description": "Value of line item thumbnail image absolute URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18345,6 +19771,7 @@
           },
           {
             "name": "validationErrors",
+            "description": "Validation errors",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18368,6 +19795,7 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -18379,6 +19807,7 @@
           },
           {
             "name": "volumetricWeight",
+            "description": "Volumetric weight value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18390,6 +19819,7 @@
           },
           {
             "name": "warehouseLocation",
+            "description": "Warehouse location",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18401,6 +19831,7 @@
           },
           {
             "name": "weight",
+            "description": "Shopping cart weight value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18412,6 +19843,7 @@
           },
           {
             "name": "weightUnit",
+            "description": "Weight unit value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18423,6 +19855,7 @@
           },
           {
             "name": "width",
+            "description": "Width value",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18441,9 +19874,11 @@
       {
         "kind": "OBJECT",
         "name": "LocalizedSettingResponseType",
+        "description": null,
         "fields": [
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -18466,6 +19901,7 @@
       {
         "kind": "SCALAR",
         "name": "Long",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -18475,9 +19911,11 @@
       {
         "kind": "OBJECT",
         "name": "MemberAddressConnection",
+        "description": "A connection from an object to a list of objects of type `MemberAddress`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -18493,6 +19931,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -18508,6 +19947,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18523,6 +19963,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18541,9 +19982,11 @@
       {
         "kind": "OBJECT",
         "name": "MemberAddressEdge",
+        "description": "An edge in a connection from an object to another object of type `MemberAddress`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18559,6 +20002,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -18577,9 +20021,11 @@
       {
         "kind": "OBJECT",
         "name": "MemberAddressType",
+        "description": null,
         "fields": [
           {
             "name": "addressType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18591,6 +20037,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18602,6 +20049,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18613,6 +20061,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18624,6 +20073,7 @@
           },
           {
             "name": "description",
+            "description": "Description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18635,6 +20085,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18646,6 +20097,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18657,6 +20109,7 @@
           },
           {
             "name": "id",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18668,6 +20121,7 @@
           },
           {
             "name": "isDefault",
+            "description": "Is default address or not",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18683,6 +20137,7 @@
           },
           {
             "name": "isFavorite",
+            "description": "Is favorite address or not",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18698,6 +20153,7 @@
           },
           {
             "name": "key",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18709,6 +20165,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18720,6 +20177,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18731,6 +20189,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18742,6 +20201,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18753,6 +20213,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18764,6 +20225,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18775,6 +20237,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18786,6 +20249,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18797,6 +20261,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18812,6 +20277,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18823,6 +20289,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18834,6 +20301,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -18852,12 +20320,15 @@
       {
         "kind": "OBJECT",
         "name": "MemberType",
+        "description": null,
         "fields": [
           {
             "name": "addresses",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -18869,6 +20340,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -18880,6 +20352,7 @@
               },
               {
                 "name": "sort",
+                "description": "Sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -18900,6 +20373,7 @@
           },
           {
             "name": "defaultBillingAddress",
+            "description": "Default billing address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -18911,6 +20385,7 @@
           },
           {
             "name": "defaultShippingAddress",
+            "description": "Default shipping address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -18922,9 +20397,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -18953,6 +20430,7 @@
           },
           {
             "name": "emails",
+            "description": "Emails",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18972,6 +20450,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18991,6 +20470,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19006,6 +20486,7 @@
           },
           {
             "name": "memberType",
+            "description": "Member type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19021,6 +20502,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19032,6 +20514,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19043,6 +20526,7 @@
           },
           {
             "name": "phones",
+            "description": "Phones",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19062,9 +20546,11 @@
           },
           {
             "name": "seoInfo",
+            "description": "Request related SEO info",
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19080,6 +20566,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19104,6 +20591,7 @@
           },
           {
             "name": "seoObjectType",
+            "description": "SEO object type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19119,6 +20607,7 @@
           },
           {
             "name": "status",
+            "description": "Status",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19137,9 +20626,11 @@
       {
         "kind": "OBJECT",
         "name": "MenuLinkListType",
+        "description": null,
         "fields": [
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19163,6 +20654,7 @@
           },
           {
             "name": "name",
+            "description": "Menu name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19178,6 +20670,7 @@
           },
           {
             "name": "outerId",
+            "description": "Menu outer ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19196,9 +20689,11 @@
       {
         "kind": "OBJECT",
         "name": "MenuLinkType",
+        "description": null,
         "fields": [
           {
             "name": "associatedObjectId",
+            "description": "Menu item object ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19210,6 +20705,7 @@
           },
           {
             "name": "associatedObjectName",
+            "description": "Menu item object name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19221,6 +20717,7 @@
           },
           {
             "name": "associatedObjectType",
+            "description": "Menu item type name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19232,6 +20729,7 @@
           },
           {
             "name": "childItems",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19255,6 +20753,7 @@
           },
           {
             "name": "outerId",
+            "description": "Menu item outerID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -19266,6 +20765,7 @@
           },
           {
             "name": "priority",
+            "description": "Menu item priority",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19281,6 +20781,7 @@
           },
           {
             "name": "title",
+            "description": "Menu item title",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19296,6 +20797,7 @@
           },
           {
             "name": "url",
+            "description": "Menu item url",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19318,9 +20820,11 @@
       {
         "kind": "OBJECT",
         "name": "MoneyType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": "A decimal with the amount rounded to the significant number of decimal digits.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19336,6 +20840,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19351,6 +20856,7 @@
           },
           {
             "name": "decimalDigits",
+            "description": "Number of decimal digits for the associated currency.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19366,6 +20872,7 @@
           },
           {
             "name": "formattedAmount",
+            "description": "Formatted amount.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19381,6 +20888,7 @@
           },
           {
             "name": "formattedAmountWithoutCurrency",
+            "description": "Formatted amount without currency.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19396,6 +20904,7 @@
           },
           {
             "name": "formattedAmountWithoutPoint",
+            "description": "Formatted amount without point.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19411,6 +20920,7 @@
           },
           {
             "name": "formattedAmountWithoutPointAndCurrency",
+            "description": "Formatted amount without point and currency.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -19433,12 +20943,15 @@
       {
         "kind": "OBJECT",
         "name": "Mutations",
+        "description": null,
         "fields": [
           {
             "name": "addAddressToFavorites",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19463,9 +20976,11 @@
           },
           {
             "name": "addBulkItemsCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19490,9 +21005,11 @@
           },
           {
             "name": "addCartAddress",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19517,9 +21034,11 @@
           },
           {
             "name": "addCoupon",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19544,9 +21063,11 @@
           },
           {
             "name": "addGiftItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19571,9 +21092,11 @@
           },
           {
             "name": "addItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19598,9 +21121,11 @@
           },
           {
             "name": "addItemsCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19625,9 +21150,11 @@
           },
           {
             "name": "addOrUpdateCartAddress",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19652,9 +21179,11 @@
           },
           {
             "name": "addOrUpdateCartPayment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19679,9 +21208,11 @@
           },
           {
             "name": "addOrUpdateCartShipment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19706,9 +21237,11 @@
           },
           {
             "name": "addOrUpdateOrderPayment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19733,9 +21266,11 @@
           },
           {
             "name": "addQuoteAttachments",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19760,9 +21295,11 @@
           },
           {
             "name": "addWishlistBulkItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19787,9 +21324,11 @@
           },
           {
             "name": "addWishlistItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19814,9 +21353,11 @@
           },
           {
             "name": "addWishlistItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19841,9 +21382,11 @@
           },
           {
             "name": "authorizePayment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19868,9 +21411,11 @@
           },
           {
             "name": "cancelQuoteRequest",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19895,9 +21440,11 @@
           },
           {
             "name": "changeCartItemComment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeCartItemCommentType",
@@ -19918,9 +21465,11 @@
           },
           {
             "name": "changeCartItemPrice",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19945,9 +21494,11 @@
           },
           {
             "name": "changeCartItemQuantity",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -19972,9 +21523,11 @@
           },
           {
             "name": "changeCartItemSelected",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeCartItemSelectedType",
@@ -19995,9 +21548,11 @@
           },
           {
             "name": "changeComment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeCommentType",
@@ -20018,9 +21573,11 @@
           },
           {
             "name": "changeOrderStatus",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20045,9 +21602,11 @@
           },
           {
             "name": "changeOrganizationContactRole",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20072,9 +21631,11 @@
           },
           {
             "name": "changePassword",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangePasswordType",
@@ -20095,9 +21656,11 @@
           },
           {
             "name": "changePurchaseOrderNumber",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangePurchaseOrderNumber",
@@ -20118,9 +21681,11 @@
           },
           {
             "name": "changeQuoteComment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20145,9 +21710,11 @@
           },
           {
             "name": "changeQuoteItemQuantity",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20172,9 +21739,11 @@
           },
           {
             "name": "changeWishlist",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20199,9 +21768,11 @@
           },
           {
             "name": "clearCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20226,9 +21797,11 @@
           },
           {
             "name": "clearPayments",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20253,9 +21826,11 @@
           },
           {
             "name": "clearShipments",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20280,9 +21855,11 @@
           },
           {
             "name": "cloneWishlist",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20307,9 +21884,11 @@
           },
           {
             "name": "confirmEmail",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20334,9 +21913,11 @@
           },
           {
             "name": "createContact",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20361,9 +21942,11 @@
           },
           {
             "name": "createCustomerReview",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20388,9 +21971,11 @@
           },
           {
             "name": "createOrderFromCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20415,9 +22000,11 @@
           },
           {
             "name": "createOrganization",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20442,9 +22029,11 @@
           },
           {
             "name": "createQuote",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20469,9 +22058,11 @@
           },
           {
             "name": "createQuoteFromCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20496,9 +22087,11 @@
           },
           {
             "name": "createUser",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20523,9 +22116,11 @@
           },
           {
             "name": "createWishlist",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20550,9 +22145,11 @@
           },
           {
             "name": "deleteContact",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20577,9 +22174,11 @@
           },
           {
             "name": "deleteFile",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20604,9 +22203,11 @@
           },
           {
             "name": "deleteMemberAddresses",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20631,9 +22232,11 @@
           },
           {
             "name": "deleteQuoteAttachments",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20658,9 +22261,11 @@
           },
           {
             "name": "deleteUsers",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20685,9 +22290,11 @@
           },
           {
             "name": "initializePayment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20712,9 +22319,11 @@
           },
           {
             "name": "inviteUser",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20739,9 +22348,11 @@
           },
           {
             "name": "lockOrganizationContact",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20766,9 +22377,11 @@
           },
           {
             "name": "mergeCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20793,9 +22406,11 @@
           },
           {
             "name": "moveWishlistItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20820,9 +22435,11 @@
           },
           {
             "name": "processOrderPayment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20847,9 +22464,11 @@
           },
           {
             "name": "refreshCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20874,9 +22493,11 @@
           },
           {
             "name": "registerByInvitation",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20901,9 +22522,11 @@
           },
           {
             "name": "rejectGiftItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20928,9 +22551,11 @@
           },
           {
             "name": "removeAddressFromFavorites",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20955,9 +22580,11 @@
           },
           {
             "name": "removeCart",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -20982,9 +22609,11 @@
           },
           {
             "name": "removeCartAddress",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21009,9 +22638,11 @@
           },
           {
             "name": "removeCartItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21036,9 +22667,11 @@
           },
           {
             "name": "removeCartItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21063,9 +22696,11 @@
           },
           {
             "name": "removeCoupon",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21090,9 +22725,11 @@
           },
           {
             "name": "removeMemberFromOrganization",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21117,9 +22754,11 @@
           },
           {
             "name": "removeQuoteItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21144,9 +22783,11 @@
           },
           {
             "name": "removeShipment",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21171,9 +22812,11 @@
           },
           {
             "name": "removeWishlist",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21198,9 +22841,11 @@
           },
           {
             "name": "removeWishlistItem",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21225,9 +22870,11 @@
           },
           {
             "name": "removeWishlistItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21252,9 +22899,11 @@
           },
           {
             "name": "renameWishlist",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21279,9 +22928,11 @@
           },
           {
             "name": "requestRegistration",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21306,9 +22957,11 @@
           },
           {
             "name": "resetPasswordByToken",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputResetPasswordByTokenType",
@@ -21329,9 +22982,11 @@
           },
           {
             "name": "selectAllCartItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeAllCartItemsSelectedType",
@@ -21352,9 +23007,11 @@
           },
           {
             "name": "selectCartItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeCartItemsSelectedType",
@@ -21375,9 +23032,11 @@
           },
           {
             "name": "sendVerifyEmail",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputSendVerifyEmailType",
@@ -21398,9 +23057,11 @@
           },
           {
             "name": "submitQuoteRequest",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21425,9 +23086,11 @@
           },
           {
             "name": "unSelectAllCartItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeAllCartItemsSelectedType",
@@ -21448,9 +23111,11 @@
           },
           {
             "name": "unSelectCartItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "InputChangeCartItemsSelectedType",
@@ -21471,9 +23136,11 @@
           },
           {
             "name": "unlockOrganizationContact",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21498,9 +23165,11 @@
           },
           {
             "name": "updateCartDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21525,9 +23194,11 @@
           },
           {
             "name": "updateCartItemDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21552,9 +23223,11 @@
           },
           {
             "name": "updateCartPaymentDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21579,9 +23252,11 @@
           },
           {
             "name": "updateCartShipmentDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21606,9 +23281,11 @@
           },
           {
             "name": "updateContact",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21633,9 +23310,11 @@
           },
           {
             "name": "updateMemberAddresses",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21660,9 +23339,11 @@
           },
           {
             "name": "updateMemberDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21687,9 +23368,11 @@
           },
           {
             "name": "updateOrderDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21714,9 +23397,11 @@
           },
           {
             "name": "updateOrderItemDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21741,9 +23426,11 @@
           },
           {
             "name": "updateOrderPaymentDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21768,9 +23455,11 @@
           },
           {
             "name": "updateOrderShipmentDynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21795,9 +23484,11 @@
           },
           {
             "name": "updateOrganization",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21822,9 +23513,11 @@
           },
           {
             "name": "updatePersonalData",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21849,9 +23542,11 @@
           },
           {
             "name": "updateQuoteAddresses",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21876,9 +23571,11 @@
           },
           {
             "name": "updateQuoteAttachments",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21903,9 +23600,11 @@
           },
           {
             "name": "updateRole",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21930,9 +23629,11 @@
           },
           {
             "name": "updateUser",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21957,9 +23658,11 @@
           },
           {
             "name": "updateWishListItems",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -21984,9 +23687,11 @@
           },
           {
             "name": "validateCoupon",
+            "description": null,
             "args": [
               {
                 "name": "command",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -22018,6 +23723,7 @@
       {
         "kind": "SCALAR",
         "name": "OptionalDecimal",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -22027,6 +23733,7 @@
       {
         "kind": "SCALAR",
         "name": "OptionalNullableDecimal",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -22036,6 +23743,7 @@
       {
         "kind": "SCALAR",
         "name": "OptionalString",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -22045,9 +23753,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderAddressType",
+        "description": null,
         "fields": [
           {
             "name": "addressType",
+            "description": "Address type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22059,6 +23769,7 @@
           },
           {
             "name": "city",
+            "description": "City",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22070,6 +23781,7 @@
           },
           {
             "name": "countryCode",
+            "description": "Country code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22081,6 +23793,7 @@
           },
           {
             "name": "countryName",
+            "description": "Country name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22092,6 +23805,7 @@
           },
           {
             "name": "email",
+            "description": "Email",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22103,6 +23817,7 @@
           },
           {
             "name": "firstName",
+            "description": "First name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22114,6 +23829,7 @@
           },
           {
             "name": "id",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22125,6 +23841,7 @@
           },
           {
             "name": "key",
+            "description": "Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22136,6 +23853,7 @@
           },
           {
             "name": "lastName",
+            "description": "Last name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22147,6 +23865,7 @@
           },
           {
             "name": "line1",
+            "description": "Line1",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22158,6 +23877,7 @@
           },
           {
             "name": "line2",
+            "description": "Line2",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22169,6 +23889,7 @@
           },
           {
             "name": "middleName",
+            "description": "Middle name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22180,6 +23901,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22191,6 +23913,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22202,6 +23925,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22213,6 +23937,7 @@
           },
           {
             "name": "phone",
+            "description": "Phone",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22224,6 +23949,7 @@
           },
           {
             "name": "postalCode",
+            "description": "Postal code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22239,6 +23965,7 @@
           },
           {
             "name": "regionId",
+            "description": "Region id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22250,6 +23977,7 @@
           },
           {
             "name": "regionName",
+            "description": "Region name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22261,6 +23989,7 @@
           },
           {
             "name": "zip",
+            "description": "Zip",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22279,9 +24008,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderDiscountType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": "Order discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22297,6 +24028,7 @@
           },
           {
             "name": "coupon",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22308,6 +24040,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22319,6 +24052,7 @@
           },
           {
             "name": "promotionId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22337,9 +24071,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderLineItemType",
+        "description": null,
         "fields": [
           {
             "name": "cancelReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22351,6 +24087,7 @@
           },
           {
             "name": "cancelledDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22362,6 +24099,7 @@
           },
           {
             "name": "catalogId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22377,6 +24115,7 @@
           },
           {
             "name": "categoryId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22388,6 +24127,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22399,6 +24139,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22414,6 +24155,7 @@
           },
           {
             "name": "discountAmount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22429,6 +24171,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22444,6 +24187,7 @@
           },
           {
             "name": "discountTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22459,6 +24203,7 @@
           },
           {
             "name": "discountTotalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22474,6 +24219,7 @@
           },
           {
             "name": "discounts",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22497,9 +24243,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Customer order Line item dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -22532,6 +24280,7 @@
           },
           {
             "name": "extendedPrice",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22547,6 +24296,7 @@
           },
           {
             "name": "extendedPriceWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22562,6 +24312,7 @@
           },
           {
             "name": "fulfillmentCenterId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22573,6 +24324,7 @@
           },
           {
             "name": "fulfillmentCenterName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22584,6 +24336,7 @@
           },
           {
             "name": "fulfillmentLocationCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22595,6 +24348,7 @@
           },
           {
             "name": "height",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22606,6 +24360,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22621,6 +24376,7 @@
           },
           {
             "name": "imageUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22632,6 +24388,7 @@
           },
           {
             "name": "isCancelled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22647,6 +24404,7 @@
           },
           {
             "name": "isGift",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22658,6 +24416,7 @@
           },
           {
             "name": "length",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22669,6 +24428,7 @@
           },
           {
             "name": "measureUnit",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22680,6 +24440,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22695,6 +24456,7 @@
           },
           {
             "name": "objectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22710,6 +24472,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22721,6 +24484,7 @@
           },
           {
             "name": "placedPrice",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22736,6 +24500,7 @@
           },
           {
             "name": "placedPriceWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22751,6 +24516,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22766,6 +24532,7 @@
           },
           {
             "name": "priceId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22777,6 +24544,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22792,6 +24560,7 @@
           },
           {
             "name": "product",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -22803,6 +24572,7 @@
           },
           {
             "name": "productId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22818,6 +24588,7 @@
           },
           {
             "name": "productOuterId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22829,6 +24600,7 @@
           },
           {
             "name": "productType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22840,6 +24612,7 @@
           },
           {
             "name": "quantity",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22855,6 +24628,7 @@
           },
           {
             "name": "reserveQuantity",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22870,6 +24644,7 @@
           },
           {
             "name": "shippingMethodCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22881,6 +24656,7 @@
           },
           {
             "name": "sku",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22896,6 +24672,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22907,6 +24684,7 @@
           },
           {
             "name": "statusDisplayValue",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22918,6 +24696,7 @@
           },
           {
             "name": "taxDetails",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22941,6 +24720,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22956,6 +24736,7 @@
           },
           {
             "name": "taxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -22971,6 +24752,7 @@
           },
           {
             "name": "taxType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -22982,6 +24764,7 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -22993,6 +24776,7 @@
           },
           {
             "name": "weight",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23004,6 +24788,7 @@
           },
           {
             "name": "weightUnit",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23015,6 +24800,7 @@
           },
           {
             "name": "width",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23033,9 +24819,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderPaymentMethodType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23051,6 +24839,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23066,6 +24855,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23077,6 +24867,7 @@
           },
           {
             "name": "discountAmount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23092,6 +24883,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23107,6 +24899,7 @@
           },
           {
             "name": "isActive",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23122,6 +24915,7 @@
           },
           {
             "name": "isAvailableForPartial",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23137,6 +24931,7 @@
           },
           {
             "name": "logoUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23148,6 +24943,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23159,6 +24955,7 @@
           },
           {
             "name": "paymentMethodGroupType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23174,6 +24971,7 @@
           },
           {
             "name": "paymentMethodType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23189,6 +24987,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23204,6 +25003,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23219,6 +25019,7 @@
           },
           {
             "name": "priority",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23234,6 +25035,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23245,6 +25047,7 @@
           },
           {
             "name": "taxDetails",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -23264,6 +25067,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23279,6 +25083,7 @@
           },
           {
             "name": "taxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23294,6 +25099,7 @@
           },
           {
             "name": "taxType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23305,6 +25111,7 @@
           },
           {
             "name": "total",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23320,6 +25127,7 @@
           },
           {
             "name": "totalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23335,6 +25143,7 @@
           },
           {
             "name": "typeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23357,9 +25166,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderShipmentItemType",
+        "description": null,
         "fields": [
           {
             "name": "barCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23371,6 +25182,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23386,6 +25198,7 @@
           },
           {
             "name": "lineItem",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -23397,6 +25210,7 @@
           },
           {
             "name": "lineItemId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23408,6 +25222,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23419,6 +25234,7 @@
           },
           {
             "name": "quantity",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23434,6 +25250,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23452,9 +25269,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderShipmentPackageType",
+        "description": null,
         "fields": [
           {
             "name": "barCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23466,6 +25285,7 @@
           },
           {
             "name": "height",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23477,6 +25297,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23492,6 +25313,7 @@
           },
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23515,6 +25337,7 @@
           },
           {
             "name": "length",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23526,6 +25349,7 @@
           },
           {
             "name": "measureUnit",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23537,6 +25361,7 @@
           },
           {
             "name": "packageType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23548,6 +25373,7 @@
           },
           {
             "name": "weight",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23559,6 +25385,7 @@
           },
           {
             "name": "weightUnit",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23570,6 +25397,7 @@
           },
           {
             "name": "width",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23588,9 +25416,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderShipmentType",
+        "description": null,
         "fields": [
           {
             "name": "cancelReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23602,6 +25432,7 @@
           },
           {
             "name": "cancelledDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23613,6 +25444,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23624,6 +25456,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23639,6 +25472,7 @@
           },
           {
             "name": "customerOrderId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23650,6 +25484,7 @@
           },
           {
             "name": "deliveryAddress",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -23661,6 +25496,7 @@
           },
           {
             "name": "deliveryDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23672,6 +25508,7 @@
           },
           {
             "name": "discountAmount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23687,6 +25524,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23702,6 +25540,7 @@
           },
           {
             "name": "discounts",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23725,9 +25564,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Customer order Shipment dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -23760,6 +25601,7 @@
           },
           {
             "name": "employeeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23771,6 +25613,7 @@
           },
           {
             "name": "employeeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23782,6 +25625,7 @@
           },
           {
             "name": "fee",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23797,6 +25641,7 @@
           },
           {
             "name": "feeWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23812,6 +25657,7 @@
           },
           {
             "name": "fulfillmentCenterId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23823,6 +25669,7 @@
           },
           {
             "name": "fulfillmentCenterName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23834,6 +25681,7 @@
           },
           {
             "name": "height",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23845,6 +25693,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23860,6 +25709,7 @@
           },
           {
             "name": "inPayments",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23883,6 +25733,7 @@
           },
           {
             "name": "isApproved",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23898,6 +25749,7 @@
           },
           {
             "name": "isCancelled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23913,6 +25765,7 @@
           },
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23936,6 +25789,7 @@
           },
           {
             "name": "length",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23947,6 +25801,7 @@
           },
           {
             "name": "measureUnit",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -23958,6 +25813,7 @@
           },
           {
             "name": "number",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23973,6 +25829,7 @@
           },
           {
             "name": "objectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -23988,6 +25845,7 @@
           },
           {
             "name": "operationType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24003,6 +25861,7 @@
           },
           {
             "name": "organizationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24014,6 +25873,7 @@
           },
           {
             "name": "organizationName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24025,6 +25885,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24036,6 +25897,7 @@
           },
           {
             "name": "packages",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24059,6 +25921,7 @@
           },
           {
             "name": "parentOperationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24070,6 +25933,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24085,6 +25949,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24100,6 +25965,7 @@
           },
           {
             "name": "shipmentMethodCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24111,6 +25977,7 @@
           },
           {
             "name": "shipmentMethodOption",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24122,6 +25989,7 @@
           },
           {
             "name": "shippingMethod",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -24133,6 +26001,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24144,6 +26013,7 @@
           },
           {
             "name": "statusDisplayValue",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24155,6 +26025,7 @@
           },
           {
             "name": "taxDetails",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24178,6 +26049,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24193,6 +26065,7 @@
           },
           {
             "name": "taxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24208,6 +26081,7 @@
           },
           {
             "name": "taxType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24219,6 +26093,7 @@
           },
           {
             "name": "total",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24234,6 +26109,7 @@
           },
           {
             "name": "totalWithTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24249,6 +26125,7 @@
           },
           {
             "name": "trackingNumber",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24260,6 +26137,7 @@
           },
           {
             "name": "trackingUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24271,6 +26149,7 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -24282,6 +26161,7 @@
           },
           {
             "name": "weight",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24293,6 +26173,7 @@
           },
           {
             "name": "weightUnit",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24304,6 +26185,7 @@
           },
           {
             "name": "width",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24322,9 +26204,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderShippingMethodType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24340,6 +26224,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24351,6 +26236,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24366,6 +26252,7 @@
           },
           {
             "name": "isActive",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24381,6 +26268,7 @@
           },
           {
             "name": "logoUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24392,6 +26280,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24403,6 +26292,7 @@
           },
           {
             "name": "priority",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24418,6 +26308,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24429,6 +26320,7 @@
           },
           {
             "name": "taxType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24440,6 +26332,7 @@
           },
           {
             "name": "typeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24458,9 +26351,11 @@
       {
         "kind": "OBJECT",
         "name": "OrderTaxDetailType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24476,6 +26371,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24491,6 +26387,7 @@
           },
           {
             "name": "rate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24513,12 +26410,15 @@
       {
         "kind": "OBJECT",
         "name": "Organization",
+        "description": "Organization info",
         "fields": [
           {
             "name": "addresses",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -24530,6 +26430,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -24541,6 +26442,7 @@
               },
               {
                 "name": "sort",
+                "description": "Sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -24561,6 +26463,7 @@
           },
           {
             "name": "businessCategory",
+            "description": "Business category",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24572,9 +26475,11 @@
           },
           {
             "name": "contacts",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -24586,6 +26491,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -24597,6 +26503,7 @@
               },
               {
                 "name": "searchPhrase",
+                "description": "Free text search",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -24608,6 +26515,7 @@
               },
               {
                 "name": "sort",
+                "description": "Sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -24628,6 +26536,7 @@
           },
           {
             "name": "defaultBillingAddress",
+            "description": "Default billing address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -24639,6 +26548,7 @@
           },
           {
             "name": "defaultShippingAddress",
+            "description": "Default shipping address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -24650,6 +26560,7 @@
           },
           {
             "name": "description",
+            "description": "Description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24661,9 +26572,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -24692,6 +26605,7 @@
           },
           {
             "name": "emails",
+            "description": "Emails",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24711,6 +26625,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24730,6 +26645,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24745,6 +26661,7 @@
           },
           {
             "name": "memberType",
+            "description": "Member type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24760,6 +26677,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24771,6 +26689,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24782,6 +26701,7 @@
           },
           {
             "name": "ownerId",
+            "description": "Owner id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24793,6 +26713,7 @@
           },
           {
             "name": "parentId",
+            "description": "Parent id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24804,6 +26725,7 @@
           },
           {
             "name": "phones",
+            "description": "Phones",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24823,9 +26745,11 @@
           },
           {
             "name": "seoInfo",
+            "description": "Request related SEO info",
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -24841,6 +26765,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -24865,6 +26790,7 @@
           },
           {
             "name": "seoObjectType",
+            "description": "SEO object type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24880,6 +26806,7 @@
           },
           {
             "name": "status",
+            "description": "Status",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24898,9 +26825,11 @@
       {
         "kind": "OBJECT",
         "name": "OrganizationConnection",
+        "description": "A connection from an object to a list of objects of type `Organization`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -24916,6 +26845,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -24931,6 +26861,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24946,6 +26877,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -24964,9 +26896,11 @@
       {
         "kind": "OBJECT",
         "name": "OrganizationEdge",
+        "description": "An edge in a connection from an object to another object of type `Organization`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -24982,6 +26916,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -25000,9 +26935,11 @@
       {
         "kind": "OBJECT",
         "name": "OutlineItemType",
+        "description": null,
         "fields": [
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25018,6 +26955,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25033,6 +26971,7 @@
           },
           {
             "name": "seoInfos",
+            "description": "SEO info",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -25052,6 +26991,7 @@
           },
           {
             "name": "seoObjectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25074,9 +27014,11 @@
       {
         "kind": "OBJECT",
         "name": "OutlineType",
+        "description": null,
         "fields": [
           {
             "name": "items",
+            "description": "Outline items",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -25103,9 +27045,11 @@
       {
         "kind": "OBJECT",
         "name": "PageConnection",
+        "description": "A connection from an object to a list of objects of type `Page`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -25121,6 +27065,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -25136,6 +27081,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25151,6 +27097,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25169,9 +27116,11 @@
       {
         "kind": "OBJECT",
         "name": "PageEdge",
+        "description": "An edge in a connection from an object to another object of type `Page`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25187,6 +27136,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -25205,9 +27155,11 @@
       {
         "kind": "OBJECT",
         "name": "PageInfo",
+        "description": "Information about pagination in a connection.",
         "fields": [
           {
             "name": "endCursor",
+            "description": "When paginating forwards, the cursor to continue.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25219,6 +27171,7 @@
           },
           {
             "name": "hasNextPage",
+            "description": "When paginating forwards, are there more items?",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25234,6 +27187,7 @@
           },
           {
             "name": "hasPreviousPage",
+            "description": "When paginating backwards, are there more items?",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25249,6 +27203,7 @@
           },
           {
             "name": "startCursor",
+            "description": "When paginating backwards, the cursor to continue.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25267,9 +27222,11 @@
       {
         "kind": "OBJECT",
         "name": "PageType",
+        "description": null,
         "fields": [
           {
             "name": "name",
+            "description": "Page title",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25281,6 +27238,7 @@
           },
           {
             "name": "permalink",
+            "description": "Page permalink",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25292,6 +27250,7 @@
           },
           {
             "name": "relativeUrl",
+            "description": "Page file relative url",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25314,9 +27273,11 @@
       {
         "kind": "OBJECT",
         "name": "PasswordOptionsType",
+        "description": null,
         "fields": [
           {
             "name": "requireDigit",
+            "description": "Require a digit ('0' - '9').",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25332,6 +27293,7 @@
           },
           {
             "name": "requireLowercase",
+            "description": "Require a lower case letter ('a' - 'z').",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25347,6 +27309,7 @@
           },
           {
             "name": "requireNonAlphanumeric",
+            "description": "Require a non letter or digit character.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25362,6 +27325,7 @@
           },
           {
             "name": "requireUppercase",
+            "description": "Require an upper case letter ('A' - 'Z').",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25377,6 +27341,7 @@
           },
           {
             "name": "requiredLength",
+            "description": "The minimum length a password must be.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25392,6 +27357,7 @@
           },
           {
             "name": "requiredUniqueChars",
+            "description": "The minimum number of unique chars a password must comprised of.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25414,9 +27380,11 @@
       {
         "kind": "OBJECT",
         "name": "PaymentInConnection",
+        "description": "A connection from an object to a list of objects of type `PaymentIn`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -25432,6 +27400,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -25447,6 +27416,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25462,6 +27432,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25480,9 +27451,11 @@
       {
         "kind": "OBJECT",
         "name": "PaymentInEdge",
+        "description": "An edge in a connection from an object to another object of type `PaymentIn`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25498,6 +27471,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -25516,9 +27490,11 @@
       {
         "kind": "OBJECT",
         "name": "PaymentInType",
+        "description": null,
         "fields": [
           {
             "name": "authorizedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25530,6 +27506,7 @@
           },
           {
             "name": "billingAddress",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -25541,6 +27518,7 @@
           },
           {
             "name": "cancelReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25552,6 +27530,7 @@
           },
           {
             "name": "cancelledDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25563,6 +27542,7 @@
           },
           {
             "name": "capturedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25574,6 +27554,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25585,6 +27566,7 @@
           },
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25596,6 +27578,7 @@
           },
           {
             "name": "createdDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25611,6 +27594,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25626,6 +27610,7 @@
           },
           {
             "name": "customerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25641,6 +27626,7 @@
           },
           {
             "name": "customerName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25652,9 +27638,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Customer order Payment dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -25687,6 +27675,7 @@
           },
           {
             "name": "gatewayCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25698,6 +27687,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25713,6 +27703,7 @@
           },
           {
             "name": "incomingDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25724,6 +27715,7 @@
           },
           {
             "name": "isApproved",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25739,6 +27731,7 @@
           },
           {
             "name": "isCancelled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25754,6 +27747,7 @@
           },
           {
             "name": "modifiedBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25765,6 +27759,7 @@
           },
           {
             "name": "modifiedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25776,6 +27771,7 @@
           },
           {
             "name": "number",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25791,6 +27787,7 @@
           },
           {
             "name": "objectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25806,6 +27803,7 @@
           },
           {
             "name": "operationType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25821,6 +27819,7 @@
           },
           {
             "name": "order",
+            "description": "Associated Order",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25836,6 +27835,7 @@
           },
           {
             "name": "orderId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25847,6 +27847,7 @@
           },
           {
             "name": "organizationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25858,6 +27859,7 @@
           },
           {
             "name": "organizationName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25869,6 +27871,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25880,6 +27883,7 @@
           },
           {
             "name": "parentOperationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25891,6 +27895,7 @@
           },
           {
             "name": "paymentMethod",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -25902,6 +27907,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25917,6 +27923,7 @@
           },
           {
             "name": "purpose",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25928,6 +27935,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25939,6 +27947,7 @@
           },
           {
             "name": "statusDisplayValue",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -25950,6 +27959,7 @@
           },
           {
             "name": "sum",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25965,6 +27975,7 @@
           },
           {
             "name": "tax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -25980,6 +27991,7 @@
           },
           {
             "name": "transactions",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26003,6 +28015,7 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -26014,6 +28027,7 @@
           },
           {
             "name": "voidedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26032,9 +28046,11 @@
       {
         "kind": "OBJECT",
         "name": "PaymentMethodType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": "Value of payment gateway code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26050,6 +28066,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26065,6 +28082,7 @@
           },
           {
             "name": "description",
+            "description": "Payment method description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26076,6 +28094,7 @@
           },
           {
             "name": "discountAmount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26091,6 +28110,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26106,6 +28126,7 @@
           },
           {
             "name": "isAvailableForPartial",
+            "description": "Is payment method available for partial payments",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26121,6 +28142,7 @@
           },
           {
             "name": "logoUrl",
+            "description": "Value of payment method logo absolute URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26132,6 +28154,7 @@
           },
           {
             "name": "name",
+            "description": "Value of payment method name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26143,6 +28166,7 @@
           },
           {
             "name": "paymentMethodGroupType",
+            "description": "Value of payment group type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26158,6 +28182,7 @@
           },
           {
             "name": "paymentMethodType",
+            "description": "Value of payment method type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26173,6 +28198,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26188,6 +28214,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": "Price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26203,6 +28230,7 @@
           },
           {
             "name": "priority",
+            "description": "Value of payment method priority",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26218,6 +28246,7 @@
           },
           {
             "name": "taxDetails",
+            "description": "Tax details",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -26237,6 +28266,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": "Tax percent rate",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26252,6 +28282,7 @@
           },
           {
             "name": "taxTotal",
+            "description": "Tax total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26267,6 +28298,7 @@
           },
           {
             "name": "taxType",
+            "description": "Tax type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26278,6 +28310,7 @@
           },
           {
             "name": "total",
+            "description": "Total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26293,6 +28326,7 @@
           },
           {
             "name": "totalWithTax",
+            "description": "Total with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26315,9 +28349,11 @@
       {
         "kind": "OBJECT",
         "name": "PaymentTransactionType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26333,6 +28369,7 @@
           },
           {
             "name": "gatewayIpAddress",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26344,6 +28381,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26359,6 +28397,7 @@
           },
           {
             "name": "isProcessed",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26374,6 +28413,7 @@
           },
           {
             "name": "note",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26385,6 +28425,7 @@
           },
           {
             "name": "processAttemptCount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26400,6 +28441,7 @@
           },
           {
             "name": "processError",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26411,6 +28453,7 @@
           },
           {
             "name": "processedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26422,6 +28465,7 @@
           },
           {
             "name": "requestData",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26433,6 +28477,7 @@
           },
           {
             "name": "responseCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26444,6 +28489,7 @@
           },
           {
             "name": "responseData",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26455,6 +28501,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26466,6 +28513,7 @@
           },
           {
             "name": "type",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26484,9 +28532,11 @@
       {
         "kind": "OBJECT",
         "name": "PaymentType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": "Amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26502,6 +28552,7 @@
           },
           {
             "name": "billingAddress",
+            "description": "Billing address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -26513,6 +28564,7 @@
           },
           {
             "name": "comment",
+            "description": "Text comment",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26524,6 +28576,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26539,6 +28592,7 @@
           },
           {
             "name": "discountAmount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26554,6 +28608,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26569,6 +28624,7 @@
           },
           {
             "name": "discounts",
+            "description": "Discounts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26588,9 +28644,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Cart payment dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -26623,6 +28681,7 @@
           },
           {
             "name": "id",
+            "description": "Payment Id",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26638,6 +28697,7 @@
           },
           {
             "name": "outerId",
+            "description": "Value of payment outer id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26649,6 +28709,7 @@
           },
           {
             "name": "paymentGatewayCode",
+            "description": "Value of payment gateway code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26660,6 +28721,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26675,6 +28737,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": "Price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26690,6 +28753,7 @@
           },
           {
             "name": "purpose",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26701,6 +28765,7 @@
           },
           {
             "name": "taxDetails",
+            "description": "Tax details",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26724,6 +28789,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": "Tax percent rate",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26739,6 +28805,7 @@
           },
           {
             "name": "taxTotal",
+            "description": "Tax total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26754,6 +28821,7 @@
           },
           {
             "name": "taxType",
+            "description": "Tax type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26765,6 +28833,7 @@
           },
           {
             "name": "total",
+            "description": "Total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26780,6 +28849,7 @@
           },
           {
             "name": "totalWithTax",
+            "description": "Total with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26795,6 +28865,7 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -26813,9 +28884,11 @@
       {
         "kind": "OBJECT",
         "name": "PriceType",
+        "description": null,
         "fields": [
           {
             "name": "actual",
+            "description": "Actual price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26831,6 +28904,7 @@
           },
           {
             "name": "actualWithTax",
+            "description": "Actual price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26846,6 +28920,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26861,6 +28936,7 @@
           },
           {
             "name": "discountAmount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26876,6 +28952,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26891,6 +28968,7 @@
           },
           {
             "name": "discountPercent",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26906,6 +28984,7 @@
           },
           {
             "name": "discounts",
+            "description": "Discounts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26929,6 +29008,7 @@
           },
           {
             "name": "endDate",
+            "description": "End date",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26940,6 +29020,7 @@
           },
           {
             "name": "list",
+            "description": "Price list",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26955,6 +29036,7 @@
           },
           {
             "name": "listWithTax",
+            "description": "Price list with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26970,6 +29052,7 @@
           },
           {
             "name": "minQuantity",
+            "description": "The product min qty",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26981,6 +29064,7 @@
           },
           {
             "name": "pricelistId",
+            "description": "The product price list",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -26992,6 +29076,7 @@
           },
           {
             "name": "sale",
+            "description": "Sale price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27007,6 +29092,7 @@
           },
           {
             "name": "saleWithTax",
+            "description": "Sale price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27022,6 +29108,7 @@
           },
           {
             "name": "startDate",
+            "description": "Start date",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27033,6 +29120,7 @@
           },
           {
             "name": "tierPrices",
+            "description": "Tier prices",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27056,6 +29144,7 @@
           },
           {
             "name": "validFrom",
+            "description": "Valid from",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27067,6 +29156,7 @@
           },
           {
             "name": "validUntil",
+            "description": "Valid until",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27085,9 +29175,11 @@
       {
         "kind": "OBJECT",
         "name": "ProcessPaymentRequestResultType",
+        "description": null,
         "fields": [
           {
             "name": "errorMessage",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27099,6 +29191,7 @@
           },
           {
             "name": "htmlForm",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27110,6 +29203,7 @@
           },
           {
             "name": "isSuccess",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27125,6 +29219,7 @@
           },
           {
             "name": "newPaymentStatus",
+            "description": "New payment status",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27136,6 +29231,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27147,6 +29243,7 @@
           },
           {
             "name": "redirectUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27165,9 +29262,11 @@
       {
         "kind": "OBJECT",
         "name": "Product",
+        "description": "Products are the sellable goods in an e-commerce project.",
         "fields": [
           {
             "name": "assets",
+            "description": "Assets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27191,9 +29290,11 @@
           },
           {
             "name": "associations",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27205,6 +29306,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -27216,6 +29318,7 @@
               },
               {
                 "name": "group",
+                "description": "association group (Accessories, RelatedItem)",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27227,6 +29330,7 @@
               },
               {
                 "name": "query",
+                "description": "the search phrase",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27247,6 +29351,7 @@
           },
           {
             "name": "availabilityData",
+            "description": "Product availability data",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27262,6 +29367,7 @@
           },
           {
             "name": "brandName",
+            "description": "Get brandName for product.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27273,6 +29379,7 @@
           },
           {
             "name": "breadcrumbs",
+            "description": "Breadcrumbs",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27296,6 +29403,7 @@
           },
           {
             "name": "catalogId",
+            "description": "The unique ID of the catalog",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27307,6 +29415,7 @@
           },
           {
             "name": "category",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -27318,6 +29427,7 @@
           },
           {
             "name": "code",
+            "description": "The product SKU.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27333,9 +29443,11 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [
               {
                 "name": "type",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27356,9 +29468,11 @@
           },
           {
             "name": "descriptions",
+            "description": null,
             "args": [
               {
                 "name": "type",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27391,6 +29505,7 @@
           },
           {
             "name": "gtin",
+            "description": "Global Trade Item Number",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27402,6 +29517,7 @@
           },
           {
             "name": "hasVariations",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27417,6 +29533,7 @@
           },
           {
             "name": "id",
+            "description": "The unique ID of the product.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27432,6 +29549,7 @@
           },
           {
             "name": "images",
+            "description": "Product images",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27455,6 +29573,7 @@
           },
           {
             "name": "imgSrc",
+            "description": "The product main image URL.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27466,6 +29585,7 @@
           },
           {
             "name": "inWishlist",
+            "description": "Product added at least in one wishlist",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27481,9 +29601,11 @@
           },
           {
             "name": "keyProperties",
+            "description": null,
             "args": [
               {
                 "name": "take",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -27516,6 +29638,7 @@
           },
           {
             "name": "masterVariation",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -27527,6 +29650,7 @@
           },
           {
             "name": "maxQuantity",
+            "description": "Max. quantity",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27538,6 +29662,7 @@
           },
           {
             "name": "minQuantity",
+            "description": "Min. quantity",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27549,6 +29674,7 @@
           },
           {
             "name": "minVariationPrice",
+            "description": "Minimim product variation price",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -27560,6 +29686,7 @@
           },
           {
             "name": "name",
+            "description": "The name of the product.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27575,6 +29702,7 @@
           },
           {
             "name": "outerId",
+            "description": "The outer identifier",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27586,6 +29714,7 @@
           },
           {
             "name": "outline",
+            "description": "All parent categories ids relative to the requested catalog and concatenated with \\ . E.g. (1/21/344)",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27597,6 +29726,7 @@
           },
           {
             "name": "outlines",
+            "description": "Outlines",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27620,6 +29750,7 @@
           },
           {
             "name": "price",
+            "description": "Product price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27635,6 +29766,7 @@
           },
           {
             "name": "prices",
+            "description": "Product prices",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27658,6 +29790,7 @@
           },
           {
             "name": "productType",
+            "description": "The type of product",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27669,9 +29802,11 @@
           },
           {
             "name": "properties",
+            "description": null,
             "args": [
               {
                 "name": "names",
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -27708,6 +29843,7 @@
           },
           {
             "name": "seoInfo",
+            "description": "Request related SEO info",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27723,6 +29859,7 @@
           },
           {
             "name": "slug",
+            "description": "Request related slug for product",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27734,6 +29871,7 @@
           },
           {
             "name": "variations",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27757,6 +29895,7 @@
           },
           {
             "name": "vendor",
+            "description": "Product vendor",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -27768,9 +29907,11 @@
           },
           {
             "name": "videos",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -27782,6 +29923,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -27809,9 +29951,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductAssociation",
+        "description": "product association.",
         "fields": [
           {
             "name": "associatedObjectId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27823,6 +29967,7 @@
           },
           {
             "name": "associatedObjectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27834,6 +29979,7 @@
           },
           {
             "name": "priority",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27849,6 +29995,7 @@
           },
           {
             "name": "product",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -27860,6 +30007,7 @@
           },
           {
             "name": "quantity",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27871,6 +30019,7 @@
           },
           {
             "name": "tags",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27894,6 +30043,7 @@
           },
           {
             "name": "type",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27916,9 +30066,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductAssociationConnection",
+        "description": "A connection from an object to a list of objects of type `ProductAssociation`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -27934,6 +30086,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -27949,6 +30102,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -27964,6 +30118,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -27982,9 +30137,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductAssociationEdge",
+        "description": "An edge in a connection from an object to another object of type `ProductAssociation`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28000,6 +30157,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -28018,9 +30176,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductConnection",
+        "description": "A connection from an object to a list of objects of type `Product`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28036,6 +30196,7 @@
           },
           {
             "name": "filter_facets",
+            "description": "Filter facets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28059,6 +30220,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28074,6 +30236,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28089,6 +30252,7 @@
           },
           {
             "name": "range_facets",
+            "description": "Range facets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28112,6 +30276,7 @@
           },
           {
             "name": "term_facets",
+            "description": "Term facets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28135,6 +30300,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28153,9 +30319,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductEdge",
+        "description": "An edge in a connection from an object to another object of type `Product`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28171,6 +30339,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -28189,9 +30358,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductSuggestionsQueryResponseType",
+        "description": null,
         "fields": [
           {
             "name": "suggestions",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28214,9 +30385,11 @@
       {
         "kind": "OBJECT",
         "name": "Promotion",
+        "description": "Represents promotion object",
         "fields": [
           {
             "name": "description",
+            "description": "Promotion description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28228,6 +30401,7 @@
           },
           {
             "name": "id",
+            "description": "The unique ID of the promotion.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28243,6 +30417,7 @@
           },
           {
             "name": "name",
+            "description": "The name of the promotion",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28258,6 +30433,7 @@
           },
           {
             "name": "type",
+            "description": "Promotion type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28276,9 +30452,11 @@
       {
         "kind": "OBJECT",
         "name": "Property",
+        "description": "Products attributes.",
         "fields": [
           {
             "name": "displayOrder",
+            "description": "The display order of the property.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28290,6 +30468,7 @@
           },
           {
             "name": "hidden",
+            "description": "Is property hidden.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28305,6 +30484,7 @@
           },
           {
             "name": "id",
+            "description": "The unique ID of the property.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28320,6 +30500,7 @@
           },
           {
             "name": "label",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28335,6 +30516,7 @@
           },
           {
             "name": "multivalue",
+            "description": "Is property has multiple values.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28350,6 +30532,7 @@
           },
           {
             "name": "name",
+            "description": "The name of the property.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28365,9 +30548,11 @@
           },
           {
             "name": "propertyDictItems",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28379,6 +30564,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -28399,9 +30585,11 @@
           },
           {
             "name": "propertyDictionaryItems",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28413,6 +30601,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -28433,6 +30622,7 @@
           },
           {
             "name": "propertyType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28448,6 +30638,7 @@
           },
           {
             "name": "propertyValueType",
+            "description": "ValueType of the property.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28463,6 +30654,7 @@
           },
           {
             "name": "type",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28478,6 +30670,7 @@
           },
           {
             "name": "value",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28489,6 +30682,7 @@
           },
           {
             "name": "valueId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28500,6 +30694,7 @@
           },
           {
             "name": "valueType",
+            "description": "ValueType of the property.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28522,9 +30717,11 @@
       {
         "kind": "OBJECT",
         "name": "PropertyConnection",
+        "description": "A connection from an object to a list of objects of type `Property`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28540,6 +30737,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28555,6 +30753,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28570,6 +30769,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28588,9 +30788,11 @@
       {
         "kind": "OBJECT",
         "name": "PropertyDictionaryItem",
+        "description": "Represents property dictionary item",
         "fields": [
           {
             "name": "id",
+            "description": "The unique ID of the property dictionary item.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28606,6 +30808,7 @@
           },
           {
             "name": "sortOrder",
+            "description": "Value order.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28621,6 +30824,7 @@
           },
           {
             "name": "value",
+            "description": "Value alias.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28639,9 +30843,11 @@
       {
         "kind": "OBJECT",
         "name": "PropertyDictionaryItemConnection",
+        "description": "A connection from an object to a list of objects of type `PropertyDictionaryItem`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28657,6 +30863,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -28672,6 +30879,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28687,6 +30895,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -28705,9 +30914,11 @@
       {
         "kind": "OBJECT",
         "name": "PropertyDictionaryItemEdge",
+        "description": "An edge in a connection from an object to another object of type `PropertyDictionaryItem`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28723,6 +30934,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -28741,9 +30953,11 @@
       {
         "kind": "OBJECT",
         "name": "PropertyEdge",
+        "description": "An edge in a connection from an object to another object of type `Property`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -28759,6 +30973,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -28777,27 +30992,32 @@
       {
         "kind": "ENUM",
         "name": "PropertyType",
+        "description": "The type of catalog property.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "CATALOG",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "CATEGORY",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "PRODUCT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "VARIATION",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -28807,6 +31027,7 @@
       {
         "kind": "SCALAR",
         "name": "PropertyValue",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -28816,42 +31037,50 @@
       {
         "kind": "ENUM",
         "name": "PropertyValueTypes",
+        "description": "The type of catalog property value.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "BOOLEAN",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "DATE_TIME",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "GEO_POINT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INTEGER",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "LONG_TEXT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "NUMBER",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SHORT_TEXT",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -28861,12 +31090,15 @@
       {
         "kind": "OBJECT",
         "name": "Query",
+        "description": null,
         "fields": [
           {
             "name": "cart",
+            "description": null,
             "args": [
               {
                 "name": "cartName",
+                "description": "Cart name",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28878,6 +31110,7 @@
               },
               {
                 "name": "cartType",
+                "description": "Cart type",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28889,6 +31122,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-Us\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28900,6 +31134,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "Currency code (\"USD\")",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -28915,6 +31150,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Store Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -28930,6 +31166,7 @@
               },
               {
                 "name": "userId",
+                "description": "User Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28950,9 +31187,11 @@
           },
           {
             "name": "carts",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28964,6 +31203,7 @@
               },
               {
                 "name": "cartType",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28975,6 +31215,7 @@
               },
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28986,6 +31227,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -28997,6 +31239,7 @@
               },
               {
                 "name": "filter",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29008,6 +31251,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29019,6 +31263,7 @@
               },
               {
                 "name": "sort",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29030,6 +31275,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29041,6 +31287,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29061,9 +31308,11 @@
           },
           {
             "name": "categories",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29075,6 +31324,7 @@
               },
               {
                 "name": "categoryIds",
+                "description": "Category Ids",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -29090,6 +31340,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "The language for which all localized category data will be returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29101,6 +31352,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "The currency for which all prices data will be returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29112,6 +31364,7 @@
               },
               {
                 "name": "facet",
+                "description": "Facets calculate statistical counts to aid in faceted navigation.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29123,6 +31376,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29134,6 +31388,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29145,6 +31400,7 @@
               },
               {
                 "name": "fuzzy",
+                "description": "When the fuzzy query parameter is set to true the search endpoint will also return categories that contain slight differences to the search text.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -29156,6 +31412,7 @@
               },
               {
                 "name": "fuzzyLevel",
+                "description": "The fuzziness level is quantified in terms of the Damerau-Levenshtein distance, this distance being the number of operations needed to transform one word into another.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29167,6 +31424,7 @@
               },
               {
                 "name": "query",
+                "description": "The query parameter performs the full-text search",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29178,6 +31436,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29189,6 +31448,7 @@
               },
               {
                 "name": "storeId",
+                "description": "The store id where category are searched",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29200,6 +31460,7 @@
               },
               {
                 "name": "userId",
+                "description": "The customer id for search result impersonation",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29220,9 +31481,11 @@
           },
           {
             "name": "category",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29234,6 +31497,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "Currency code (\"USD\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29245,6 +31509,7 @@
               },
               {
                 "name": "id",
+                "description": "id of the product",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29260,6 +31525,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Store Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29275,6 +31541,7 @@
               },
               {
                 "name": "userId",
+                "description": "User Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29295,9 +31562,11 @@
           },
           {
             "name": "checkEmailUniqueness",
+            "description": null,
             "args": [
               {
                 "name": "email",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29322,9 +31591,11 @@
           },
           {
             "name": "checkUsernameUniqueness",
+            "description": null,
             "args": [
               {
                 "name": "username",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29349,9 +31620,11 @@
           },
           {
             "name": "childCategories",
+            "description": null,
             "args": [
               {
                 "name": "categoryId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29363,6 +31636,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Currency code (\"USD\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29374,6 +31648,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29385,6 +31660,7 @@
               },
               {
                 "name": "maxLevel",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29396,6 +31672,7 @@
               },
               {
                 "name": "onlyActive",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -29407,6 +31684,7 @@
               },
               {
                 "name": "productFilter",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29418,6 +31696,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Store Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29433,6 +31712,7 @@
               },
               {
                 "name": "userId",
+                "description": "User Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29453,9 +31733,11 @@
           },
           {
             "name": "contact",
+            "description": null,
             "args": [
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29471,6 +31753,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29491,9 +31774,11 @@
           },
           {
             "name": "contacts",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29505,6 +31790,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29516,6 +31802,7 @@
               },
               {
                 "name": "searchPhrase",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29527,6 +31814,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29547,9 +31835,11 @@
           },
           {
             "name": "contract",
+            "description": null,
             "args": [
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29570,6 +31860,7 @@
           },
           {
             "name": "countries",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -29593,9 +31884,11 @@
           },
           {
             "name": "customerReviews",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29607,6 +31900,7 @@
               },
               {
                 "name": "entityId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29622,6 +31916,7 @@
               },
               {
                 "name": "entityType",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29637,6 +31932,7 @@
               },
               {
                 "name": "filter",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29648,6 +31944,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29659,6 +31956,7 @@
               },
               {
                 "name": "keyword",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29670,6 +31968,7 @@
               },
               {
                 "name": "sort",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29681,6 +31980,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29705,9 +32005,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29719,6 +32021,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "The culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29730,6 +32033,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29741,6 +32045,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -29752,6 +32057,7 @@
               },
               {
                 "name": "objectType",
+                "description": "Object type of the dynamic property",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29763,6 +32069,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29783,9 +32090,11 @@
           },
           {
             "name": "dynamicProperty",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29797,6 +32106,7 @@
               },
               {
                 "name": "idOrName",
+                "description": "Id or name of the dynamic property",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29812,6 +32122,7 @@
               },
               {
                 "name": "objectType",
+                "description": "Object type of the dynamic property",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29832,9 +32143,11 @@
           },
           {
             "name": "evaluateDynamicContent",
+            "description": null,
             "args": [
               {
                 "name": "categoryId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29846,6 +32159,7 @@
               },
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29857,6 +32171,7 @@
               },
               {
                 "name": "placeName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29868,6 +32183,7 @@
               },
               {
                 "name": "productId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29879,6 +32195,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29890,6 +32207,7 @@
               },
               {
                 "name": "tags",
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -29905,6 +32223,7 @@
               },
               {
                 "name": "toDate",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -29916,6 +32235,7 @@
               },
               {
                 "name": "userGroups",
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -29940,9 +32260,11 @@
           },
           {
             "name": "fileUploadOptions",
+            "description": null,
             "args": [
               {
                 "name": "scope",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -29963,9 +32285,11 @@
           },
           {
             "name": "fulfillmentCenter",
+            "description": null,
             "args": [
               {
                 "name": "id",
+                "description": "ID of the Fulfilment Center",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -29990,9 +32314,11 @@
           },
           {
             "name": "fulfillmentCenters",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30004,6 +32330,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30015,6 +32342,7 @@
               },
               {
                 "name": "fulfillmentCenterIds",
+                "description": "Filter by FFC IDs",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -30030,6 +32358,7 @@
               },
               {
                 "name": "query",
+                "description": "Search FFC by name",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30041,6 +32370,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30052,6 +32382,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Search FFCs attached to a store",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30072,6 +32403,7 @@
           },
           {
             "name": "me",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -30083,9 +32415,11 @@
           },
           {
             "name": "menu",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30101,6 +32435,7 @@
               },
               {
                 "name": "name",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30116,6 +32451,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30140,9 +32476,11 @@
           },
           {
             "name": "menus",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30154,6 +32492,7 @@
               },
               {
                 "name": "keyword",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30165,6 +32504,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30201,9 +32541,11 @@
           },
           {
             "name": "order",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30215,6 +32557,7 @@
               },
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30226,6 +32569,7 @@
               },
               {
                 "name": "number",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30246,9 +32590,11 @@
           },
           {
             "name": "orderLineItemStatuses",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30269,9 +32615,11 @@
           },
           {
             "name": "orderStatuses",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30292,9 +32640,11 @@
           },
           {
             "name": "orders",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30306,6 +32656,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30317,6 +32668,7 @@
               },
               {
                 "name": "facet",
+                "description": "This parameter applies a facet to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30328,6 +32680,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30339,6 +32692,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30350,6 +32704,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30361,6 +32716,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30381,9 +32737,11 @@
           },
           {
             "name": "organization",
+            "description": null,
             "args": [
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30399,6 +32757,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30419,9 +32778,11 @@
           },
           {
             "name": "organizationContracts",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30433,6 +32794,7 @@
               },
               {
                 "name": "endDate",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -30444,6 +32806,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30455,6 +32818,7 @@
               },
               {
                 "name": "organizationId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30470,6 +32834,7 @@
               },
               {
                 "name": "startDate",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "DateTime",
@@ -30481,6 +32846,7 @@
               },
               {
                 "name": "statuses",
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -30496,6 +32862,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30507,6 +32874,7 @@
               },
               {
                 "name": "vendorId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30527,9 +32895,11 @@
           },
           {
             "name": "organizationOrders",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30541,6 +32911,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30552,6 +32923,7 @@
               },
               {
                 "name": "facet",
+                "description": "This parameter applies a facet to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30563,6 +32935,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30574,6 +32947,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30585,6 +32959,7 @@
               },
               {
                 "name": "organizationId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30596,6 +32971,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30616,9 +32992,11 @@
           },
           {
             "name": "organizations",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30630,6 +33008,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30641,6 +33020,7 @@
               },
               {
                 "name": "searchPhrase",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30652,6 +33032,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30672,9 +33053,11 @@
           },
           {
             "name": "pages",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30686,6 +33069,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "The language for which all localized category data will be returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30697,6 +33081,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30708,6 +33093,7 @@
               },
               {
                 "name": "keyword",
+                "description": "The keyword parameter performs the full-text search",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30723,6 +33109,7 @@
               },
               {
                 "name": "storeId",
+                "description": "The store id where pages are searched",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30747,9 +33134,11 @@
           },
           {
             "name": "paymentStatuses",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30770,9 +33159,11 @@
           },
           {
             "name": "payments",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30784,6 +33175,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30795,6 +33187,7 @@
               },
               {
                 "name": "facet",
+                "description": "This parameter applies a facet to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30806,6 +33199,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30817,6 +33211,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30828,6 +33223,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30839,6 +33235,7 @@
               },
               {
                 "name": "userId",
+                "description": "",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30859,9 +33256,11 @@
           },
           {
             "name": "product",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30873,6 +33272,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "Currency code (\"USD\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30884,6 +33284,7 @@
               },
               {
                 "name": "custom",
+                "description": "Can be used for custom query parameters",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30895,6 +33296,7 @@
               },
               {
                 "name": "id",
+                "description": "id of the product",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30910,6 +33312,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Store Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30925,6 +33328,7 @@
               },
               {
                 "name": "userId",
+                "description": "User Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30945,9 +33349,11 @@
           },
           {
             "name": "productSuggestions",
+            "description": null,
             "args": [
               {
                 "name": "query",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -30959,6 +33365,7 @@
               },
               {
                 "name": "size",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -30970,6 +33377,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -30994,9 +33402,11 @@
           },
           {
             "name": "products",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31008,6 +33418,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "The culture name for cart context product",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31019,6 +33430,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "The currency for which all prices data will be returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31030,6 +33442,7 @@
               },
               {
                 "name": "custom",
+                "description": "Can be used for custom query parameters",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31041,6 +33454,7 @@
               },
               {
                 "name": "facet",
+                "description": "Facets calculate statistical counts to aid in faceted navigation.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31052,6 +33466,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31063,6 +33478,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -31074,6 +33490,7 @@
               },
               {
                 "name": "fuzzy",
+                "description": "When the fuzzy query parameter is set to true the search endpoint will also return products that contain slight differences to the search text.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -31085,6 +33502,7 @@
               },
               {
                 "name": "fuzzyLevel",
+                "description": "The fuzziness level is quantified in terms of the Damerau-Levenshtein distance, this distance being the number of operations needed to transform one word into another.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -31096,6 +33514,7 @@
               },
               {
                 "name": "productIds",
+                "description": "Product Ids",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -31111,6 +33530,7 @@
               },
               {
                 "name": "query",
+                "description": "The query parameter performs the full-text search",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31122,6 +33542,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31133,6 +33554,7 @@
               },
               {
                 "name": "storeId",
+                "description": "The store id where products are searched",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31148,6 +33570,7 @@
               },
               {
                 "name": "userId",
+                "description": "The customer id for search result impersonation",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31168,9 +33591,11 @@
           },
           {
             "name": "properties",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31182,6 +33607,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "The language for which all localized property dictionary items will be returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31193,6 +33619,7 @@
               },
               {
                 "name": "filter",
+                "description": "This parameter applies a filter to the query results",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31204,6 +33631,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -31215,6 +33643,7 @@
               },
               {
                 "name": "storeId",
+                "description": "The store id to get associated catalog",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31230,6 +33659,7 @@
               },
               {
                 "name": "types",
+                "description": "The owner types (Catalog, Category, Product, Variation)",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -31254,9 +33684,11 @@
           },
           {
             "name": "property",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": "The language for which all localized property dictionary items will be returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31268,6 +33700,7 @@
               },
               {
                 "name": "id",
+                "description": "id of the property",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31292,9 +33725,11 @@
           },
           {
             "name": "quote",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31306,6 +33741,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31317,6 +33753,7 @@
               },
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31328,6 +33765,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31339,6 +33777,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31359,6 +33798,7 @@
           },
           {
             "name": "quoteAttachmentOptions",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -31370,9 +33810,11 @@
           },
           {
             "name": "quotes",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31384,6 +33826,7 @@
               },
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31395,6 +33838,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31406,6 +33850,7 @@
               },
               {
                 "name": "filter",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31417,6 +33862,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -31428,6 +33874,7 @@
               },
               {
                 "name": "keyword",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31439,6 +33886,7 @@
               },
               {
                 "name": "sort",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31450,6 +33898,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31461,6 +33910,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31481,9 +33931,11 @@
           },
           {
             "name": "regions",
+            "description": null,
             "args": [
               {
                 "name": "countryId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31520,9 +33972,11 @@
           },
           {
             "name": "requestPasswordReset",
+            "description": null,
             "args": [
               {
                 "name": "loginOrEmail",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31538,6 +33992,7 @@
               },
               {
                 "name": "urlSuffix",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31558,9 +34013,11 @@
           },
           {
             "name": "role",
+            "description": null,
             "args": [
               {
                 "name": "roleName",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31585,9 +34042,11 @@
           },
           {
             "name": "shipmentStatuses",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31608,9 +34067,11 @@
           },
           {
             "name": "slugInfo",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31622,6 +34083,7 @@
               },
               {
                 "name": "slug",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31633,6 +34095,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31644,6 +34107,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31664,9 +34128,11 @@
           },
           {
             "name": "store",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31678,6 +34144,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31702,9 +34169,11 @@
           },
           {
             "name": "user",
+            "description": null,
             "args": [
               {
                 "name": "email",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31716,6 +34185,7 @@
               },
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31727,6 +34197,7 @@
               },
               {
                 "name": "loginProvider",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31738,6 +34209,7 @@
               },
               {
                 "name": "providerKey",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31749,6 +34221,7 @@
               },
               {
                 "name": "userName",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31769,9 +34242,11 @@
           },
           {
             "name": "validateCoupon",
+            "description": null,
             "args": [
               {
                 "name": "cartId",
+                "description": "Cart Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31783,6 +34258,7 @@
               },
               {
                 "name": "cartName",
+                "description": "Cart name",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31794,6 +34270,7 @@
               },
               {
                 "name": "cartType",
+                "description": "Cart type",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31805,6 +34282,7 @@
               },
               {
                 "name": "coupon",
+                "description": "Cart promo coupon code",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31820,6 +34298,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-Us\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31831,6 +34310,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "Currency code (\"USD\")",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31846,6 +34326,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Store Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31861,6 +34342,7 @@
               },
               {
                 "name": "userId",
+                "description": "User Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31885,9 +34367,11 @@
           },
           {
             "name": "validatePassword",
+            "description": null,
             "args": [
               {
                 "name": "password",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31912,9 +34396,11 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [
               {
                 "name": "id",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31930,6 +34416,7 @@
               },
               {
                 "name": "userId",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31950,9 +34437,11 @@
           },
           {
             "name": "wishlist",
+            "description": null,
             "args": [
               {
                 "name": "cultureName",
+                "description": "Culture name (\"en-Us\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -31964,6 +34453,7 @@
               },
               {
                 "name": "listId",
+                "description": "List Id",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -31988,9 +34478,11 @@
           },
           {
             "name": "wishlists",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32002,6 +34494,7 @@
               },
               {
                 "name": "cultureName",
+                "description": "Culture Name",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32013,6 +34506,7 @@
               },
               {
                 "name": "currencyCode",
+                "description": "Currency Code",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32024,6 +34518,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -32035,6 +34530,7 @@
               },
               {
                 "name": "scope",
+                "description": "List scope",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32046,6 +34542,7 @@
               },
               {
                 "name": "sort",
+                "description": "The sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32057,6 +34554,7 @@
               },
               {
                 "name": "storeId",
+                "description": "Store Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32068,6 +34566,7 @@
               },
               {
                 "name": "userId",
+                "description": "User Id",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -32095,9 +34594,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteAddressType",
+        "description": null,
         "fields": [
           {
             "name": "addressType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32109,6 +34610,7 @@
           },
           {
             "name": "city",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32124,6 +34626,7 @@
           },
           {
             "name": "countryCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32135,6 +34638,7 @@
           },
           {
             "name": "countryName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32150,6 +34654,7 @@
           },
           {
             "name": "email",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32161,6 +34666,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32176,6 +34682,7 @@
           },
           {
             "name": "id",
+            "description": "ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32187,6 +34694,7 @@
           },
           {
             "name": "key",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32198,6 +34706,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32213,6 +34722,7 @@
           },
           {
             "name": "line1",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32224,6 +34734,7 @@
           },
           {
             "name": "line2",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32235,6 +34746,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32246,6 +34758,7 @@
           },
           {
             "name": "organization",
+            "description": "Company name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32257,6 +34770,7 @@
           },
           {
             "name": "outerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32268,6 +34782,7 @@
           },
           {
             "name": "phone",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32279,6 +34794,7 @@
           },
           {
             "name": "postalCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32290,6 +34806,7 @@
           },
           {
             "name": "regionId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32301,6 +34818,7 @@
           },
           {
             "name": "regionName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32319,9 +34837,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteAttachmentType",
+        "description": null,
         "fields": [
           {
             "name": "contentType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32333,6 +34853,7 @@
           },
           {
             "name": "mimeType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32344,6 +34865,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32359,6 +34881,7 @@
           },
           {
             "name": "size",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32374,6 +34897,7 @@
           },
           {
             "name": "url",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32396,9 +34920,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteConnection",
+        "description": "A connection from an object to a list of objects of type `Quote`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -32414,6 +34940,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -32429,6 +34956,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32444,6 +34972,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32462,9 +34991,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteEdge",
+        "description": "An edge in a connection from an object to another object of type `Quote`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32480,6 +35011,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -32498,9 +35030,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteItemType",
+        "description": null,
         "fields": [
           {
             "name": "catalogId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32516,6 +35050,7 @@
           },
           {
             "name": "categoryId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32527,6 +35062,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32538,6 +35074,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32553,6 +35090,7 @@
           },
           {
             "name": "imageUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32564,6 +35102,7 @@
           },
           {
             "name": "listPrice",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32579,6 +35118,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32594,6 +35134,7 @@
           },
           {
             "name": "product",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -32605,6 +35146,7 @@
           },
           {
             "name": "productId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32620,6 +35162,7 @@
           },
           {
             "name": "proposalPrices",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32643,6 +35186,7 @@
           },
           {
             "name": "salePrice",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32658,6 +35202,7 @@
           },
           {
             "name": "selectedTierPrice",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -32669,6 +35214,7 @@
           },
           {
             "name": "sku",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32684,6 +35230,7 @@
           },
           {
             "name": "taxType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32702,9 +35249,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteShipmentMethodType",
+        "description": null,
         "fields": [
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32720,6 +35269,7 @@
           },
           {
             "name": "logoUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32731,6 +35281,7 @@
           },
           {
             "name": "optionName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32742,6 +35293,7 @@
           },
           {
             "name": "price",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32757,6 +35309,7 @@
           },
           {
             "name": "shipmentMethodCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32772,6 +35325,7 @@
           },
           {
             "name": "typeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32790,9 +35344,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteTaxDetailType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32808,6 +35364,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -32819,6 +35376,7 @@
           },
           {
             "name": "rate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32841,9 +35399,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteTierPriceType",
+        "description": null,
         "fields": [
           {
             "name": "price",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32859,6 +35419,7 @@
           },
           {
             "name": "quantity",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32881,9 +35442,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteTotalsType",
+        "description": null,
         "fields": [
           {
             "name": "adjustmentQuoteExlTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32899,6 +35462,7 @@
           },
           {
             "name": "discountTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32914,6 +35478,7 @@
           },
           {
             "name": "grandTotalExlTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32929,6 +35494,7 @@
           },
           {
             "name": "grandTotalInclTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32944,6 +35510,7 @@
           },
           {
             "name": "originalSubTotalExlTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32959,6 +35526,7 @@
           },
           {
             "name": "shippingTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32974,6 +35542,7 @@
           },
           {
             "name": "subTotalExlTax",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -32989,6 +35558,7 @@
           },
           {
             "name": "taxTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33011,9 +35581,11 @@
       {
         "kind": "OBJECT",
         "name": "QuoteType",
+        "description": null,
         "fields": [
           {
             "name": "addresses",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33037,6 +35609,7 @@
           },
           {
             "name": "attachments",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33060,6 +35633,7 @@
           },
           {
             "name": "cancelReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33071,6 +35645,7 @@
           },
           {
             "name": "cancelledDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33082,6 +35657,7 @@
           },
           {
             "name": "channelId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33093,6 +35669,7 @@
           },
           {
             "name": "comment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33104,6 +35681,7 @@
           },
           {
             "name": "coupon",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33115,6 +35693,7 @@
           },
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33126,6 +35705,7 @@
           },
           {
             "name": "createdDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33141,6 +35721,7 @@
           },
           {
             "name": "currency",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33156,6 +35737,7 @@
           },
           {
             "name": "customerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33167,6 +35749,7 @@
           },
           {
             "name": "customerName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33178,9 +35761,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Quote dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -33213,6 +35798,7 @@
           },
           {
             "name": "employeeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33224,6 +35810,7 @@
           },
           {
             "name": "employeeName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33235,6 +35822,7 @@
           },
           {
             "name": "enableNotification",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33250,6 +35838,7 @@
           },
           {
             "name": "expirationDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33261,6 +35850,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33276,6 +35866,7 @@
           },
           {
             "name": "innerComment",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33287,6 +35878,7 @@
           },
           {
             "name": "isAnonymous",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33302,6 +35894,7 @@
           },
           {
             "name": "isCancelled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33317,6 +35910,7 @@
           },
           {
             "name": "isLocked",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33332,6 +35926,7 @@
           },
           {
             "name": "items",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33355,6 +35950,7 @@
           },
           {
             "name": "languageCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33366,6 +35962,7 @@
           },
           {
             "name": "manualRelDiscountAmount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33381,6 +35978,7 @@
           },
           {
             "name": "manualShippingTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33396,6 +35994,7 @@
           },
           {
             "name": "manualSubTotal",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33411,6 +36010,7 @@
           },
           {
             "name": "modifiedBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33422,6 +36022,7 @@
           },
           {
             "name": "modifiedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33433,6 +36034,7 @@
           },
           {
             "name": "number",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33448,6 +36050,7 @@
           },
           {
             "name": "objectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33459,6 +36062,7 @@
           },
           {
             "name": "organizationId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33470,6 +36074,7 @@
           },
           {
             "name": "organizationName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33481,6 +36086,7 @@
           },
           {
             "name": "reminderDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33492,6 +36098,7 @@
           },
           {
             "name": "shipmentMethod",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -33503,6 +36110,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33514,6 +36122,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33529,6 +36138,7 @@
           },
           {
             "name": "tag",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33540,6 +36150,7 @@
           },
           {
             "name": "taxDetails",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33563,6 +36174,7 @@
           },
           {
             "name": "totals",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33585,9 +36197,11 @@
       {
         "kind": "OBJECT",
         "name": "RangeFacet",
+        "description": null,
         "fields": [
           {
             "name": "facetType",
+            "description": "The three types of facets. Terms, Range, Filter",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33603,6 +36217,7 @@
           },
           {
             "name": "label",
+            "description": "Localized name of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33618,6 +36233,7 @@
           },
           {
             "name": "name",
+            "description": "The key/name  of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33633,6 +36249,7 @@
           },
           {
             "name": "ranges",
+            "description": "Ranges",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33669,9 +36286,11 @@
       {
         "kind": "OBJECT",
         "name": "Rating",
+        "description": null,
         "fields": [
           {
             "name": "reviewCount",
+            "description": "Total count of customer reviews",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33687,6 +36306,7 @@
           },
           {
             "name": "value",
+            "description": "Average rating",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33709,10 +36329,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RefreshCartType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "cartId",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -33724,6 +36346,7 @@
           },
           {
             "name": "cartName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -33735,6 +36358,7 @@
           },
           {
             "name": "cartType",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -33746,6 +36370,7 @@
           },
           {
             "name": "cultureName",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -33757,6 +36382,7 @@
           },
           {
             "name": "currencyCode",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -33768,6 +36394,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -33783,6 +36410,7 @@
           },
           {
             "name": "userId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -33804,9 +36432,11 @@
       {
         "kind": "OBJECT",
         "name": "RegisterAccountType",
+        "description": null,
         "fields": [
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33818,6 +36448,7 @@
           },
           {
             "name": "email",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33833,6 +36464,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33848,6 +36480,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33859,6 +36492,7 @@
           },
           {
             "name": "username",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33881,9 +36515,11 @@
       {
         "kind": "OBJECT",
         "name": "RegisterContactType",
+        "description": null,
         "fields": [
           {
             "name": "about",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33895,6 +36531,7 @@
           },
           {
             "name": "address",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -33906,6 +36543,7 @@
           },
           {
             "name": "birthdate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33917,6 +36555,7 @@
           },
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -33928,9 +36567,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Contact's dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -33955,6 +36596,7 @@
           },
           {
             "name": "firstName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33970,6 +36612,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -33985,6 +36628,7 @@
           },
           {
             "name": "lastName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34000,6 +36644,7 @@
           },
           {
             "name": "middleName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34011,6 +36656,7 @@
           },
           {
             "name": "phoneNumber",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34022,6 +36668,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34040,9 +36687,11 @@
       {
         "kind": "OBJECT",
         "name": "RegisterOrganizationType",
+        "description": null,
         "fields": [
           {
             "name": "address",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34054,6 +36703,7 @@
           },
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34065,6 +36715,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34076,9 +36727,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Contact's dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -34103,6 +36756,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34118,6 +36772,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34133,6 +36788,7 @@
           },
           {
             "name": "ownerId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34144,6 +36800,7 @@
           },
           {
             "name": "status",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34162,9 +36819,11 @@
       {
         "kind": "OBJECT",
         "name": "RegistrationErrorType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34176,6 +36835,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34187,6 +36847,7 @@
           },
           {
             "name": "parameter",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34205,10 +36866,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RemoveAddressFromFavoritesCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addressId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -34230,10 +36893,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "RemoveQuoteItemCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "lineItemId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -34249,6 +36914,7 @@
           },
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -34270,9 +36936,11 @@
       {
         "kind": "OBJECT",
         "name": "RequestRegistrationType",
+        "description": null,
         "fields": [
           {
             "name": "account",
+            "description": "Contact's account",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34284,6 +36952,7 @@
           },
           {
             "name": "contact",
+            "description": "Created contact",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34295,6 +36964,7 @@
           },
           {
             "name": "organization",
+            "description": "Created company",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34306,6 +36976,7 @@
           },
           {
             "name": "result",
+            "description": "Account creation result",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34324,9 +36995,11 @@
       {
         "kind": "OBJECT",
         "name": "RoleType",
+        "description": null,
         "fields": [
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34338,6 +37011,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34353,6 +37027,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34368,6 +37043,7 @@
           },
           {
             "name": "normalizedName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34383,6 +37059,7 @@
           },
           {
             "name": "permissions",
+            "description": "Permissions in Role",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34409,9 +37086,11 @@
       {
         "kind": "OBJECT",
         "name": "SeoInfo",
+        "description": null,
         "fields": [
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34427,6 +37106,7 @@
           },
           {
             "name": "imageAltDescription",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34438,6 +37118,7 @@
           },
           {
             "name": "isActive",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34453,6 +37134,7 @@
           },
           {
             "name": "languageCode",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34464,6 +37146,7 @@
           },
           {
             "name": "metaDescription",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34475,6 +37158,7 @@
           },
           {
             "name": "metaKeywords",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34486,6 +37170,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34497,6 +37182,7 @@
           },
           {
             "name": "objectId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34512,6 +37198,7 @@
           },
           {
             "name": "objectType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34527,6 +37214,7 @@
           },
           {
             "name": "pageTitle",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34538,6 +37226,7 @@
           },
           {
             "name": "semanticUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34553,6 +37242,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34571,9 +37261,11 @@
       {
         "kind": "OBJECT",
         "name": "ShipmentType",
+        "description": null,
         "fields": [
           {
             "name": "comment",
+            "description": "Text comment",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34585,6 +37277,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34600,6 +37293,7 @@
           },
           {
             "name": "deliveryAddress",
+            "description": "Delivery address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34611,6 +37305,7 @@
           },
           {
             "name": "discountAmount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34626,6 +37321,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34641,6 +37337,7 @@
           },
           {
             "name": "discounts",
+            "description": "Discounts",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34664,9 +37361,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Cart shipment dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -34699,6 +37398,7 @@
           },
           {
             "name": "fee",
+            "description": "Fee",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34714,6 +37414,7 @@
           },
           {
             "name": "feeWithTax",
+            "description": "Fee with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34729,6 +37430,7 @@
           },
           {
             "name": "fulfillmentCenterId",
+            "description": "Fulfillment center id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34740,6 +37442,7 @@
           },
           {
             "name": "height",
+            "description": "Value of height",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34751,6 +37454,7 @@
           },
           {
             "name": "id",
+            "description": "Shipment Id",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34766,6 +37470,7 @@
           },
           {
             "name": "items",
+            "description": "Items",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34789,6 +37494,7 @@
           },
           {
             "name": "length",
+            "description": "Value of length",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34800,6 +37506,7 @@
           },
           {
             "name": "measureUnit",
+            "description": "Value of measurement units",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34811,6 +37518,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34826,6 +37534,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": "Price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34841,6 +37550,7 @@
           },
           {
             "name": "shipmentMethodCode",
+            "description": "Shipment method code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34852,6 +37562,7 @@
           },
           {
             "name": "shipmentMethodOption",
+            "description": "Shipment method option",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34863,6 +37574,7 @@
           },
           {
             "name": "shippingMethod",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34874,6 +37586,7 @@
           },
           {
             "name": "taxDetails",
+            "description": "Tax details",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34897,6 +37610,7 @@
           },
           {
             "name": "taxPercentRate",
+            "description": "Tax percent rate",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34912,6 +37626,7 @@
           },
           {
             "name": "taxTotal",
+            "description": "Tax total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34927,6 +37642,7 @@
           },
           {
             "name": "taxType",
+            "description": "Tax type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34938,6 +37654,7 @@
           },
           {
             "name": "total",
+            "description": "Total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34953,6 +37670,7 @@
           },
           {
             "name": "totalWithTax",
+            "description": "Total with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -34968,6 +37686,7 @@
           },
           {
             "name": "vendor",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -34979,6 +37698,7 @@
           },
           {
             "name": "volumetricWeight",
+            "description": "Value of volumetric weight",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -34990,6 +37710,7 @@
           },
           {
             "name": "weight",
+            "description": "Value of weight",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35001,6 +37722,7 @@
           },
           {
             "name": "weightUnit",
+            "description": "Value of weight unit",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35012,6 +37734,7 @@
           },
           {
             "name": "width",
+            "description": "Value of width",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35030,9 +37753,11 @@
       {
         "kind": "OBJECT",
         "name": "ShippingMethodType",
+        "description": null,
         "fields": [
           {
             "name": "code",
+            "description": "Value of shipping gateway code",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35048,6 +37773,7 @@
           },
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35063,6 +37789,7 @@
           },
           {
             "name": "description",
+            "description": "Shipping method description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35074,6 +37801,7 @@
           },
           {
             "name": "discountAmount",
+            "description": "Discount amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35089,6 +37817,7 @@
           },
           {
             "name": "discountAmountWithTax",
+            "description": "Discount amount with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35104,6 +37833,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35119,6 +37849,7 @@
           },
           {
             "name": "logoUrl",
+            "description": "Value of shipping method logo absolute URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35130,6 +37861,7 @@
           },
           {
             "name": "name",
+            "description": "Shipping method name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35141,6 +37873,7 @@
           },
           {
             "name": "optionDescription",
+            "description": "Value of shipping method option description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35152,6 +37885,7 @@
           },
           {
             "name": "optionName",
+            "description": "Value of shipping method option name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35163,6 +37897,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35178,6 +37913,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": "Price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35193,6 +37929,7 @@
           },
           {
             "name": "priority",
+            "description": "Value of shipping method priority",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35208,6 +37945,7 @@
           },
           {
             "name": "total",
+            "description": "Total",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35223,6 +37961,7 @@
           },
           {
             "name": "totalWithTax",
+            "description": "Total with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35245,9 +37984,11 @@
       {
         "kind": "OBJECT",
         "name": "SlugInfoResponseType",
+        "description": null,
         "fields": [
           {
             "name": "entityInfo",
+            "description": "SEO info",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -35266,9 +38007,11 @@
       {
         "kind": "OBJECT",
         "name": "StoreResponseType",
+        "description": null,
         "fields": [
           {
             "name": "availableCurrencies",
+            "description": "Available currencies",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35292,6 +38035,7 @@
           },
           {
             "name": "availableLanguages",
+            "description": "Available languages",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35315,6 +38059,7 @@
           },
           {
             "name": "catalogId",
+            "description": "Store catalog ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35330,6 +38075,7 @@
           },
           {
             "name": "defaultCurrency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35345,6 +38091,7 @@
           },
           {
             "name": "defaultLanguage",
+            "description": "Language",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35360,6 +38107,7 @@
           },
           {
             "name": "settings",
+            "description": "Store settings",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35375,6 +38123,7 @@
           },
           {
             "name": "storeId",
+            "description": "Store ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35390,6 +38139,7 @@
           },
           {
             "name": "storeName",
+            "description": "Store name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35405,6 +38155,7 @@
           },
           {
             "name": "storeUrl",
+            "description": "Store URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35423,9 +38174,11 @@
       {
         "kind": "OBJECT",
         "name": "StoreSettingsType",
+        "description": null,
         "fields": [
           {
             "name": "anonymousUsersAllowed",
+            "description": "Allow anonymous users to visit the store ",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35441,6 +38194,7 @@
           },
           {
             "name": "createAnonymousOrderEnabled",
+            "description": "Allow anonymous users to create orders (XAPI)",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35456,6 +38210,7 @@
           },
           {
             "name": "emailVerificationEnabled",
+            "description": "Email address verification enabled",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35471,6 +38226,7 @@
           },
           {
             "name": "emailVerificationRequired",
+            "description": "Email address verification required",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35486,6 +38242,7 @@
           },
           {
             "name": "isSpa",
+            "description": "SPA",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35501,6 +38258,7 @@
           },
           {
             "name": "passwordRequirements",
+            "description": "Password requirements",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -35512,6 +38270,7 @@
           },
           {
             "name": "quotesEnabled",
+            "description": "Store ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35527,6 +38286,7 @@
           },
           {
             "name": "seoLinkType",
+            "description": "SEO links",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35542,6 +38302,7 @@
           },
           {
             "name": "subscriptionEnabled",
+            "description": "Store ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35557,6 +38318,7 @@
           },
           {
             "name": "taxCalculationEnabled",
+            "description": "Tax calculation enabled",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35579,6 +38341,7 @@
       {
         "kind": "SCALAR",
         "name": "String",
+        "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -35588,10 +38351,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "SubmitQuoteCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "comment",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -35607,6 +38372,7 @@
           },
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -35628,9 +38394,11 @@
       {
         "kind": "OBJECT",
         "name": "TaxDetailType",
+        "description": null,
         "fields": [
           {
             "name": "amount",
+            "description": "Amount",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35646,6 +38414,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35657,6 +38426,7 @@
           },
           {
             "name": "price",
+            "description": "Price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35672,6 +38442,7 @@
           },
           {
             "name": "rate",
+            "description": "Rate",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35694,9 +38465,11 @@
       {
         "kind": "OBJECT",
         "name": "TermFacet",
+        "description": null,
         "fields": [
           {
             "name": "facetType",
+            "description": "Three facet types: Terms, Range, and Filter",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35712,6 +38485,7 @@
           },
           {
             "name": "label",
+            "description": "Localized name of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35727,6 +38501,7 @@
           },
           {
             "name": "name",
+            "description": "The key/name  of the facet.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35742,6 +38517,7 @@
           },
           {
             "name": "terms",
+            "description": "Terms",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35778,9 +38554,11 @@
       {
         "kind": "OBJECT",
         "name": "TierPriceType",
+        "description": null,
         "fields": [
           {
             "name": "price",
+            "description": "Price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35796,6 +38574,7 @@
           },
           {
             "name": "priceWithTax",
+            "description": "Price with tax",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35811,6 +38590,7 @@
           },
           {
             "name": "quantity",
+            "description": "Quantity",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35833,10 +38613,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "UpdateQuoteAddressesCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "addresses",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -35856,6 +38638,7 @@
           },
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -35877,10 +38660,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "UpdateQuoteAttachmentsCommandType",
+        "description": null,
         "fields": null,
         "inputFields": [
           {
             "name": "quoteId",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -35896,6 +38681,7 @@
           },
           {
             "name": "urls",
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -35921,9 +38707,11 @@
       {
         "kind": "OBJECT",
         "name": "UserType",
+        "description": null,
         "fields": [
           {
             "name": "accessFailedCount",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35939,6 +38727,7 @@
           },
           {
             "name": "contact",
+            "description": "The associated contact info",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -35950,6 +38739,7 @@
           },
           {
             "name": "createdBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35961,6 +38751,7 @@
           },
           {
             "name": "createdDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35972,6 +38763,7 @@
           },
           {
             "name": "email",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -35983,6 +38775,7 @@
           },
           {
             "name": "emailConfirmed",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -35998,6 +38791,7 @@
           },
           {
             "name": "forcePasswordChange",
+            "description": "Make this user change their password when they sign in next time",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36009,6 +38803,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36024,6 +38819,7 @@
           },
           {
             "name": "isAdministrator",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36039,6 +38835,7 @@
           },
           {
             "name": "lockedState",
+            "description": "Account locked state",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36050,6 +38847,7 @@
           },
           {
             "name": "lockoutEnabled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36065,6 +38863,7 @@
           },
           {
             "name": "lockoutEnd",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36076,6 +38875,7 @@
           },
           {
             "name": "memberId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36087,6 +38887,7 @@
           },
           {
             "name": "modifiedBy",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36098,6 +38899,7 @@
           },
           {
             "name": "modifiedDate",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36109,6 +38911,7 @@
           },
           {
             "name": "normalizedEmail",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36120,6 +38923,7 @@
           },
           {
             "name": "normalizedUserName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36131,6 +38935,7 @@
           },
           {
             "name": "operator",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -36142,6 +38947,7 @@
           },
           {
             "name": "passwordExpired",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36157,6 +38963,7 @@
           },
           {
             "name": "passwordExpiryInDays",
+            "description": "Password expiry in days",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36168,6 +38975,7 @@
           },
           {
             "name": "permissions",
+            "description": "Account permissions",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -36183,6 +38991,7 @@
           },
           {
             "name": "phoneNumber",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36194,6 +39003,7 @@
           },
           {
             "name": "phoneNumberConfirmed",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36209,6 +39019,7 @@
           },
           {
             "name": "photoUrl",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36220,6 +39031,7 @@
           },
           {
             "name": "roles",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -36235,6 +39047,7 @@
           },
           {
             "name": "securityStamp",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36250,6 +39063,7 @@
           },
           {
             "name": "storeId",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36261,6 +39075,7 @@
           },
           {
             "name": "twoFactorEnabled",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36276,6 +39091,7 @@
           },
           {
             "name": "userName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36291,6 +39107,7 @@
           },
           {
             "name": "userType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36309,9 +39126,11 @@
       {
         "kind": "OBJECT",
         "name": "ValidationErrorType",
+        "description": null,
         "fields": [
           {
             "name": "errorCode",
+            "description": "Error code",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36323,6 +39142,7 @@
           },
           {
             "name": "errorMessage",
+            "description": "Error msg",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36334,6 +39154,7 @@
           },
           {
             "name": "errorParameters",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -36349,6 +39170,7 @@
           },
           {
             "name": "objectId",
+            "description": "Object id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36360,6 +39182,7 @@
           },
           {
             "name": "objectType",
+            "description": "Object type",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36378,9 +39201,11 @@
       {
         "kind": "OBJECT",
         "name": "VariationType",
+        "description": null,
         "fields": [
           {
             "name": "assets",
+            "description": "Assets",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36404,6 +39229,7 @@
           },
           {
             "name": "availabilityData",
+            "description": "Availability data",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36419,6 +39245,7 @@
           },
           {
             "name": "code",
+            "description": "SKU of variation.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36434,6 +39261,7 @@
           },
           {
             "name": "id",
+            "description": "Id of variation.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36449,6 +39277,7 @@
           },
           {
             "name": "images",
+            "description": "Product images",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36472,6 +39301,7 @@
           },
           {
             "name": "maxQuantity",
+            "description": "Max. quantity.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36483,6 +39313,7 @@
           },
           {
             "name": "minQuantity",
+            "description": "Min. quantity.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36494,6 +39325,7 @@
           },
           {
             "name": "name",
+            "description": "Name of variation.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36509,6 +39341,7 @@
           },
           {
             "name": "outlines",
+            "description": "Outlines",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -36528,6 +39361,7 @@
           },
           {
             "name": "price",
+            "description": "Product price",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36543,6 +39377,7 @@
           },
           {
             "name": "prices",
+            "description": "Product prices",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36566,6 +39401,7 @@
           },
           {
             "name": "productType",
+            "description": "The type of product",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36577,6 +39413,7 @@
           },
           {
             "name": "properties",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36600,6 +39437,7 @@
           },
           {
             "name": "slug",
+            "description": "Request related slug for product",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36611,6 +39449,7 @@
           },
           {
             "name": "vendor",
+            "description": "Product vendor",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -36629,9 +39468,11 @@
       {
         "kind": "OBJECT",
         "name": "Vendor",
+        "description": "Vendor Info",
         "fields": [
           {
             "name": "about",
+            "description": "About vendor",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36643,9 +39484,11 @@
           },
           {
             "name": "addresses",
+            "description": null,
             "args": [
               {
                 "name": "after",
+                "description": "Only return edges after the specified cursor.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -36657,6 +39500,7 @@
               },
               {
                 "name": "first",
+                "description": "Specifies the maximum number of edges to return, starting after the cursor specified by 'after', or the first number of edges if 'after' is not specified.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -36668,6 +39512,7 @@
               },
               {
                 "name": "sort",
+                "description": "Sort expression",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -36688,6 +39533,7 @@
           },
           {
             "name": "defaultBillingAddress",
+            "description": "Default billing address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -36699,6 +39545,7 @@
           },
           {
             "name": "defaultShippingAddress",
+            "description": "Default shipping address",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -36710,9 +39557,11 @@
           },
           {
             "name": "dynamicProperties",
+            "description": "Dynamic property values",
             "args": [
               {
                 "name": "cultureName",
+                "description": "Filter multilingual dynamic properties to return only values of specified language (\"en-US\")",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -36741,6 +39590,7 @@
           },
           {
             "name": "emails",
+            "description": "Emails",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36760,6 +39610,7 @@
           },
           {
             "name": "groups",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36779,6 +39630,7 @@
           },
           {
             "name": "iconUrl",
+            "description": "Icon URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36790,6 +39642,7 @@
           },
           {
             "name": "id",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36805,6 +39658,7 @@
           },
           {
             "name": "memberType",
+            "description": "Member type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36820,6 +39674,7 @@
           },
           {
             "name": "name",
+            "description": "Name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36831,6 +39686,7 @@
           },
           {
             "name": "outerId",
+            "description": "Outer ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36842,6 +39698,7 @@
           },
           {
             "name": "phones",
+            "description": "Phones",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36861,9 +39718,11 @@
           },
           {
             "name": "rating",
+            "description": "Vendor rating",
             "args": [
               {
                 "name": "storeId",
+                "description": "Filter vendor ratings to return only values for specified store",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -36884,9 +39743,11 @@
           },
           {
             "name": "seoInfo",
+            "description": "Request related SEO info",
             "args": [
               {
                 "name": "cultureName",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -36902,6 +39763,7 @@
               },
               {
                 "name": "storeId",
+                "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -36926,6 +39788,7 @@
           },
           {
             "name": "seoObjectType",
+            "description": "SEO object type",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -36941,6 +39804,7 @@
           },
           {
             "name": "siteUrl",
+            "description": "Site URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36952,6 +39816,7 @@
           },
           {
             "name": "status",
+            "description": "Status",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -36970,9 +39835,11 @@
       {
         "kind": "OBJECT",
         "name": "VideoConnection",
+        "description": "A connection from an object to a list of objects of type `Video`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -36988,6 +39855,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -37003,6 +39871,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37018,6 +39887,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37036,9 +39906,11 @@
       {
         "kind": "OBJECT",
         "name": "VideoEdge",
+        "description": "An edge in a connection from an object to another object of type `Video`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37054,6 +39926,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -37072,9 +39945,11 @@
       {
         "kind": "OBJECT",
         "name": "VideoType",
+        "description": null,
         "fields": [
           {
             "name": "contentUrl",
+            "description": "Video URL",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37090,6 +39965,7 @@
           },
           {
             "name": "cultureName",
+            "description": "Culture name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37101,6 +39977,7 @@
           },
           {
             "name": "description",
+            "description": "Video description",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37116,6 +39993,7 @@
           },
           {
             "name": "duration",
+            "description": "Video duration",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37127,6 +40005,7 @@
           },
           {
             "name": "embedUrl",
+            "description": "Embeded video URL",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37138,6 +40017,7 @@
           },
           {
             "name": "name",
+            "description": "Video name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37153,6 +40033,7 @@
           },
           {
             "name": "ownerId",
+            "description": "ID of the object video is attached to",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37168,6 +40049,7 @@
           },
           {
             "name": "ownerType",
+            "description": "Type of the object video is attached to (Product, Category)",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37183,6 +40065,7 @@
           },
           {
             "name": "sortOrder",
+            "description": "Sort order",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37198,6 +40081,7 @@
           },
           {
             "name": "thumbnailUrl",
+            "description": "Video thumbnial URL",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37213,6 +40097,7 @@
           },
           {
             "name": "uploadDate",
+            "description": "Video upload date",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37231,9 +40116,11 @@
       {
         "kind": "OBJECT",
         "name": "WishlistConnection",
+        "description": "A connection from an object to a list of objects of type `Wishlist`.",
         "fields": [
           {
             "name": "edges",
+            "description": "A list of all of the edges returned in the connection.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -37249,6 +40136,7 @@
           },
           {
             "name": "items",
+            "description": "A list of all of the objects returned in the connection. This is a convenience field provided for quickly exploring the API; rather than querying for \"{ edges { node } }\" when no edge data is needed, this field can be used instead. Note that when clients like Relay need to fetch the \"cursor\" field on the edge to enable efficient pagination, this shortcut cannot be used, and the full \"{ edges { node } } \" version should be used instead.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -37264,6 +40152,7 @@
           },
           {
             "name": "pageInfo",
+            "description": "Information to aid in pagination.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37279,6 +40168,7 @@
           },
           {
             "name": "totalCount",
+            "description": "A count of the total number of objects in this connection, ignoring pagination. This allows a client to fetch the first five objects by passing \"5\" as the argument to `first`, then fetch the total count so it could display \"5 of 83\", for example. In cases where we employ infinite scrolling or don't have an exact count of entries, this field will return `null`.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37297,9 +40187,11 @@
       {
         "kind": "OBJECT",
         "name": "WishlistEdge",
+        "description": "An edge in a connection from an object to another object of type `Wishlist`.",
         "fields": [
           {
             "name": "cursor",
+            "description": "A cursor for use in pagination",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37315,6 +40207,7 @@
           },
           {
             "name": "node",
+            "description": "The item at the end of the edge",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -37333,17 +40226,20 @@
       {
         "kind": "ENUM",
         "name": "WishlistScopeType",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "Organization",
+            "description": "Organization scope",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "Private",
+            "description": "Private scope",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -37353,9 +40249,11 @@
       {
         "kind": "OBJECT",
         "name": "WishlistType",
+        "description": null,
         "fields": [
           {
             "name": "currency",
+            "description": "Currency",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -37367,6 +40265,7 @@
           },
           {
             "name": "customerId",
+            "description": "Shopping cart user ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37378,6 +40277,7 @@
           },
           {
             "name": "customerName",
+            "description": "Shopping cart user name",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37389,6 +40289,7 @@
           },
           {
             "name": "description",
+            "description": "Wishlist description",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37400,6 +40301,7 @@
           },
           {
             "name": "id",
+            "description": "Shopping cart ID",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37415,6 +40317,7 @@
           },
           {
             "name": "items",
+            "description": "Items",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -37430,6 +40333,7 @@
           },
           {
             "name": "itemsCount",
+            "description": "Item count",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37441,6 +40345,7 @@
           },
           {
             "name": "modifiedDate",
+            "description": "Wishlist modified date",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37452,6 +40357,7 @@
           },
           {
             "name": "name",
+            "description": "Shopping cart name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37467,6 +40373,7 @@
           },
           {
             "name": "scope",
+            "description": "Wishlist scope",
             "args": [],
             "type": {
               "kind": "ENUM",
@@ -37478,6 +40385,7 @@
           },
           {
             "name": "storeId",
+            "description": "Shopping cart store ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37496,9 +40404,11 @@
       {
         "kind": "OBJECT",
         "name": "__Directive",
+        "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
         "fields": [
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37514,6 +40424,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37525,6 +40436,7 @@
           },
           {
             "name": "isRepeatable",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37540,6 +40452,7 @@
           },
           {
             "name": "locations",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37563,9 +40476,11 @@
           },
           {
             "name": "args",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -37605,102 +40520,122 @@
       {
         "kind": "ENUM",
         "name": "__DirectiveLocation",
+        "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "QUERY",
+            "description": "Location adjacent to a query operation.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "MUTATION",
+            "description": "Location adjacent to a mutation operation.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SUBSCRIPTION",
+            "description": "Location adjacent to a subscription operation.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "FIELD",
+            "description": "Location adjacent to a field.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "FRAGMENT_DEFINITION",
+            "description": "Location adjacent to a fragment definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "FRAGMENT_SPREAD",
+            "description": "Location adjacent to a fragment spread.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INLINE_FRAGMENT",
+            "description": "Location adjacent to an inline fragment.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "VARIABLE_DEFINITION",
+            "description": "Location adjacent to a variable definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SCHEMA",
+            "description": "Location adjacent to a schema definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "SCALAR",
+            "description": "Location adjacent to a scalar definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "OBJECT",
+            "description": "Location adjacent to an object type definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "FIELD_DEFINITION",
+            "description": "Location adjacent to a field definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "ARGUMENT_DEFINITION",
+            "description": "Location adjacent to an argument definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INTERFACE",
+            "description": "Location adjacent to an interface definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UNION",
+            "description": "Location adjacent to a union definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "ENUM",
+            "description": "Location adjacent to an enum definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "ENUM_VALUE",
+            "description": "Location adjacent to an enum value definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INPUT_OBJECT",
+            "description": "Location adjacent to an input object type definition.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INPUT_FIELD_DEFINITION",
+            "description": "Location adjacent to an input object field definition.",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -37710,9 +40645,11 @@
       {
         "kind": "OBJECT",
         "name": "__EnumValue",
+        "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
         "fields": [
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37728,6 +40665,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37739,6 +40677,7 @@
           },
           {
             "name": "isDeprecated",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37754,6 +40693,7 @@
           },
           {
             "name": "deprecationReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37772,9 +40712,11 @@
       {
         "kind": "OBJECT",
         "name": "__Field",
+        "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
         "fields": [
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37790,6 +40732,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37801,9 +40744,11 @@
           },
           {
             "name": "args",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -37836,6 +40781,7 @@
           },
           {
             "name": "type",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37851,6 +40797,7 @@
           },
           {
             "name": "isDeprecated",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37866,6 +40813,7 @@
           },
           {
             "name": "deprecationReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37884,9 +40832,11 @@
       {
         "kind": "OBJECT",
         "name": "__InputValue",
+        "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
         "fields": [
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37902,6 +40852,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37913,6 +40864,7 @@
           },
           {
             "name": "type",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37928,6 +40880,7 @@
           },
           {
             "name": "defaultValue",
+            "description": "A GraphQL-formatted string representing the default value for this input value.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37939,6 +40892,7 @@
           },
           {
             "name": "isDeprecated",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -37954,6 +40908,7 @@
           },
           {
             "name": "deprecationReason",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37972,9 +40927,11 @@
       {
         "kind": "OBJECT",
         "name": "__Schema",
+        "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
         "fields": [
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37986,6 +40943,7 @@
           },
           {
             "name": "types",
+            "description": "A list of all types supported by this server.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -38009,6 +40967,7 @@
           },
           {
             "name": "queryType",
+            "description": "The type that query operations will be rooted at.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -38024,6 +40983,7 @@
           },
           {
             "name": "mutationType",
+            "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -38035,6 +40995,7 @@
           },
           {
             "name": "subscriptionType",
+            "description": "If this server support subscription, the type that subscription operations will be rooted at.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -38046,6 +41007,7 @@
           },
           {
             "name": "directives",
+            "description": "A list of all directives supported by this server.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -38076,9 +41038,11 @@
       {
         "kind": "OBJECT",
         "name": "__Type",
+        "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
         "fields": [
           {
             "name": "kind",
+            "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -38094,6 +41058,7 @@
           },
           {
             "name": "name",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -38105,6 +41070,7 @@
           },
           {
             "name": "description",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -38116,6 +41082,7 @@
           },
           {
             "name": "specifiedByURL",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -38127,9 +41094,11 @@
           },
           {
             "name": "fields",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -38158,6 +41127,7 @@
           },
           {
             "name": "interfaces",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -38177,6 +41147,7 @@
           },
           {
             "name": "possibleTypes",
+            "description": null,
             "args": [],
             "type": {
               "kind": "LIST",
@@ -38196,9 +41167,11 @@
           },
           {
             "name": "enumValues",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -38227,9 +41200,11 @@
           },
           {
             "name": "inputFields",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
@@ -38258,6 +41233,7 @@
           },
           {
             "name": "ofType",
+            "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -38276,47 +41252,56 @@
       {
         "kind": "ENUM",
         "name": "__TypeKind",
+        "description": "An enum describing what kind of type a given `__Type` is.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
           {
             "name": "SCALAR",
+            "description": "Indicates this type is a scalar.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "OBJECT",
+            "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INTERFACE",
+            "description": "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UNION",
+            "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "ENUM",
+            "description": "Indicates this type is an enum. `enumValues` is a valid field.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "INPUT_OBJECT",
+            "description": "Indicates this type is an input object. `inputFields` is a valid field.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "LIST",
+            "description": "Indicates this type is a list. `ofType` is a valid field.",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "NON_NULL",
+            "description": "Indicates this type is a non-null. `ofType` is a valid field.",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -38327,6 +41312,7 @@
     "directives": [
       {
         "name": "deprecated",
+        "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
         "locations": [
           "ENUM_VALUE",
@@ -38335,6 +41321,7 @@
         "args": [
           {
             "name": "reason",
+            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -38348,6 +41335,7 @@
       },
       {
         "name": "include",
+        "description": "Directs the executor to include this field or fragment only when the 'if' argument is true.",
         "isRepeatable": false,
         "locations": [
           "FIELD",
@@ -38357,6 +41345,7 @@
         "args": [
           {
             "name": "if",
+            "description": "Included when true.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -38374,6 +41363,7 @@
       },
       {
         "name": "skip",
+        "description": "Directs the executor to skip this field or fragment when the 'if' argument is true.",
         "isRepeatable": false,
         "locations": [
           "FIELD",
@@ -38383,6 +41373,7 @@
         "args": [
           {
             "name": "if",
+            "description": "Skipped when true.",
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/graphql-codegen.schema.config.ts
+++ b/graphql-codegen.schema.config.ts
@@ -5,9 +5,6 @@ const graphQLCodegenSchemaConfig: CodegenConfig = {
   generates: {
     "client-app/core/api/graphql/schema.json": {
       plugins: ["introspection"],
-      config: {
-        descriptions: false,
-      },
     },
   },
 };

--- a/graphql-codegen.types.config.ts
+++ b/graphql-codegen.types.config.ts
@@ -17,7 +17,7 @@ type OperationDocument = CustomDocumentLoader;
 type CodegenConfigWorkaround = { documents: OperationDocument | OperationDocument[] };
 
 const graphQLCodegenTypesConfig: CodegenConfig | CodegenConfigWorkaround = {
-  schema: `${process.env.APP_BACKEND_URL}/xapi/graphql`,
+  schema: `client-app/core/api/graphql/schema.json`,
   documents: {
     "client-app/**/*.(graphql|gql)": {
       skipGraphQLImport: false,


### PR DESCRIPTION
## Description
You can generate graphql types using already downloaded schema via `yarn generate:graphql:types`. It didn't work before because url was used instead of downloaded file. This is usable when you need to re-generate types for existing queries/mutations and don't want to add new types available (may be temporary) on dev.

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.54.0-pr-1011-7530-75309481.zip
