### PR TITLE
fix: show product name as plain text for deleted product at list details page

### DIFF
--- a/client-app/shared/wishlists/components/wishlist-line-items.vue
+++ b/client-app/shared/wishlists/components/wishlist-line-items.vue
@@ -23,6 +23,7 @@
         :actual-price="item.actualPrice"
         :total="item.extendedPrice"
         :disabled="pendingItems[item.id]"
+        :deleted="item.deleted"
         with-image
         with-properties
         with-price

--- a/client-app/shared/wishlists/components/wishlist-line-items.vue
+++ b/client-app/shared/wishlists/components/wishlist-line-items.vue
@@ -7,10 +7,12 @@
     removable
     @remove:items="$emit('remove:items', $event)"
   >
-    <template #default></template>
+    <template #default />
+
     <template #titles>
       <div :style="{ width: itemDefaultSlotWidth }" />
     </template>
+
     <template #line-items>
       <VcLineItem
         v-for="item in items"
@@ -58,7 +60,12 @@
             <CountInCart :product-id="item.productId" />
           </div>
         </div>
+
         <template #after>
+          <VcAlert v-if="item.deleted" color="danger" size="sm" variant="outline-dark" icon>
+            {{ $t("validation_error.CART_PRODUCT_UNAVAILABLE") }}
+          </VcAlert>
+
           <div v-if="validationErrors.length" class="flex flex-col gap-1">
             <template v-for="(validationError, index) in validationErrors" :key="index">
               <VcAlert


### PR DESCRIPTION
## Description

Show product name as plain text for deleted product at list details page

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1281

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.60.0-pr-1129-2632-2632992f.zip