### PR TITLE
fix: keep selected filters values on popup on click outside on company members page

### DIFF
--- a/client-app/pages/company/members.vue
+++ b/client-app/pages/company/members.vue
@@ -582,7 +582,7 @@ function openEditCustomerRoleModal(contact: ExtendedContactType): void {
 onClickOutside(
   filtersDropdownElement,
   () => {
-    hideFilters();
+    filtersVisible.value = false;
   },
   { ignore: [filtersButtonElement] },
 );


### PR DESCRIPTION
## Description

Keep selected filters values on popup on click outside on company members page

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1229

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-1.60.0-pr-1130-3751-37510e67.zip