### PR TITLE
chore: use common links in both apollo clients

### DIFF
--- a/client-app/core/api/graphql/client.ts
+++ b/client-app/core/api/graphql/client.ts
@@ -1,22 +1,14 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client/core";
-import { cache, deprecatedLink, link, options } from "@/core/api/graphql/config";
+import { cache, link, options } from "@/core/api/graphql/config";
 
 const fetchPolicy = "no-cache";
 
 /**
  * Non-cached version of Apollo Client
- *
- * @deprecated
- *
- * Use {@link apolloClient} instead.
- *
- * **IMPORTANT!** Because of cache usage, query deduplication and `@vue/apollo-composable` usage,
- * you can't just replace {@link graphqlClient} with {@link apolloClient} in your code.
- * Look at https://github.com/VirtoCommerce/vc-theme-b2b-vue/pull/868 for more information.
  */
 export const graphqlClient = new ApolloClient({
   ...options,
-  link: deprecatedLink,
+  link,
 
   cache: new InMemoryCache({
     addTypename: false,

--- a/client-app/core/api/graphql/config/links.ts
+++ b/client-app/core/api/graphql/config/links.ts
@@ -20,15 +20,15 @@ const wsLink = new WebSocketLink(
 
 const sharedLink = from([removeTypenameFromVariables(), errorHandlerLink]);
 
-export const deprecatedLink = from([sharedLink, httpLink]);
-
 // https://www.apollographql.com/docs/react/api/link/introduction/#composing-a-link-chain
 // Tree:
-//         removeTypenameLink
-//                  ↓
-//          errorHandlerLink
-//          ↓               ↓
-// (conditional links) → httpLink
+// removeTypenameLink
+// ↓
+// errorHandlerLink
+// ↓
+// (conditional links)
+// ↓
+// httpLink
 export const link = from([
   sharedLink,
   // Add conditional links here

--- a/client-app/core/api/graphql/config/links.ts
+++ b/client-app/core/api/graphql/config/links.ts
@@ -28,7 +28,7 @@ const sharedLink = from([removeTypenameFromVariables(), errorHandlerLink]);
 // ↓
 // (conditional links)
 // ↓
-// httpLink
+// wsLink/httpLink
 export const link = from([
   sharedLink,
   // Add conditional links here


### PR DESCRIPTION
## Description
We can safely use `link` instead of `deprecatedLink`, because the first one differs by having cartLink and condition use `wsLink` for subscriptions and `httpLink` for others.
Cart link has a defined list of operations it will be applied for. So it doesn't influence anything else.
The second also works perfectly well, because all subscriptions should use wsLink (actually we have only one which already use our "new" client.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1706
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.4.0-pr-1272-548b-548ba682.zip