### PR TITLE
fix: `mobile menu` after switch `shallowRef` to `ref`

### DIFF
--- a/client-app/core/composables/useNavigations.ts
+++ b/client-app/core/composables/useNavigations.ts
@@ -21,7 +21,7 @@ import type { DeepPartial } from "utility-types";
 
 const loading = ref(false);
 const matchingRouteName = ref("");
-const menuSchema = ref<MenuType | null>(null);
+const menuSchema = shallowRef<MenuType | null>(null);
 const catalogMenuItems = shallowRef<ExtendedMenuLinkType[]>([]);
 const openedMenuItemsStack = shallowRef<ExtendedMenuLinkType[]>([]);
 const footerLinks = shallowRef<ExtendedMenuLinkType[]>([]);
@@ -213,6 +213,7 @@ export function useNavigations() {
         return objValue.concat(srcValue) as ExtendedMenuLinkType[];
       }
     });
+    triggerRef(menuSchema);
   }
 
   return {


### PR DESCRIPTION
## Description

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1919
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.6.0-pr-1348-f460-f46060b8.zip